### PR TITLE
Add talleres y educación page and navigation updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
 # CLE_BROKER
+
+Sitio estático para CLE_BROKER desarrollado con Bootstrap y componentes personalizados.
+
+## Rutas principales
+
+- `/` – Inicio con portafolio destacado y enlaces a servicios.
+- `/sobre-nosotros.html` – Información corporativa y valores.
+- `/servicios.html` – Catálogo de servicios inmobiliarios.
+- `/contacto.html` – Formulario general de contacto y datos de soporte.
+- `/faq.html` – Preguntas frecuentes sobre los servicios.
+- `/talleres.html` – Nueva página de **Talleres y Educación** para empresas.
+
+## Página de talleres
+
+La nueva página incluye:
+
+- Hero con los CTAs **“Explorar talleres (Presenciales)”**, **“Cotizar para empresas”** y **“Solicita información”**.
+- Grid de temas destacados con tarjetas reutilizando los estilos existentes.
+- Beneficios clave y métricas para empresas.
+- Formulario de cotización que reutiliza la lógica de validación `contactForm`.
+- Sección de FAQ breve para resolver dudas comunes.
+
+## Desarrollo
+
+- HTML5 + Bootstrap 4
+- Hojas de estilo en `css/`
+- Scripts existentes en `js/`
+
+Para visualizar el sitio basta con abrir cualquiera de los archivos `.html` en un navegador moderno.

--- a/contacto.html
+++ b/contacto.html
@@ -39,6 +39,7 @@
           <li class="nav-item"><a class="nav-link" href="index.html">Inicio</a></li>
           <li class="nav-item"><a class="nav-link" href="sobre-nosotros.html">Sobre Nosotros</a></li>
           <li class="nav-item"><a class="nav-link active" href="contacto.html">Contacto</a></li>
+          <li class="nav-item"><a class="nav-link" href="talleres.html">Talleres y Educación</a></li>
           <li class="nav-item"><a class="nav-link" href="servicios.html">Servicios</a></li>
           <li class="nav-item"><a class="nav-link" href="faq.html">FAQ</a></li>
         </ul>

--- a/css/talleres.page.css
+++ b/css/talleres.page.css
@@ -1,0 +1,257 @@
+.workshops-hero .hero-overlay {
+  background: linear-gradient(115deg, rgba(15, 23, 42, 0.9) 8%, rgba(37, 99, 235, 0.72) 60%, rgba(124, 58, 237, 0.68) 100%);
+}
+
+.workshops-hero .hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-top: 2rem;
+}
+
+.workshops-hero .hero-actions .improved-btn,
+.workshops-hero .hero-actions .btn-secondary-outline {
+  min-width: 220px;
+  text-align: center;
+}
+
+.btn-ghost {
+  background: rgba(255, 255, 255, 0.16);
+  color: #fff;
+  border: 1px solid rgba(255, 255, 255, 0.45);
+  box-shadow: 0 18px 45px rgba(148, 163, 184, 0.25);
+}
+
+.btn-ghost:hover,
+.btn-ghost:focus {
+  background: rgba(255, 255, 255, 0.26);
+  color: #fff;
+  transform: translateY(-4px);
+}
+
+.workshops-hero-card {
+  padding: 2.6rem 2.8rem;
+  border-radius: var(--radius-lg);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.workshops-themes .section-heading {
+  max-width: 720px;
+  margin: 0 auto 3rem;
+}
+
+.workshop-card {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  transition: transform 0.35s ease, box-shadow 0.35s ease;
+}
+
+.workshop-card:hover {
+  transform: translateY(-10px);
+  box-shadow: var(--shadow-hover);
+}
+
+.workshop-card__media {
+  position: relative;
+  overflow: hidden;
+}
+
+.workshop-card__image {
+  width: 100%;
+  height: 220px;
+  object-fit: cover;
+  transition: transform 0.5s ease;
+}
+
+.workshop-card:hover .workshop-card__image {
+  transform: scale(1.06);
+}
+
+.workshop-card__body {
+  padding: 2.2rem 2.1rem 2.4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+}
+
+.workshop-card__body h3 {
+  font-size: 1.35rem;
+  margin-bottom: 0.2rem;
+}
+
+.workshop-card__body p {
+  margin-bottom: 0;
+}
+
+.workshop-card__body .btn-secondary-outline {
+  align-self: flex-start;
+}
+
+.workshops-benefits__card {
+  padding: 2.6rem 2.8rem;
+}
+
+.workshops-benefits__summary {
+  padding: 2.8rem 3rem;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 1.4rem;
+}
+
+.benefits-metrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 1.2rem;
+}
+
+.benefits-metrics strong {
+  font-size: 1.6rem;
+  color: var(--color-primary);
+}
+
+.workshops-quote .quote-panel {
+  padding: 3rem 3.2rem;
+  border-radius: 30px;
+  background: rgba(255, 255, 255, 0.8);
+  border: 1px solid rgba(37, 99, 235, 0.12);
+  box-shadow: 0 26px 60px rgba(37, 99, 235, 0.18);
+}
+
+.list-check-inline {
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+  margin: 1.5rem 0 0;
+}
+
+.list-check-inline li {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  color: var(--color-muted);
+}
+
+.list-check-inline i {
+  color: var(--color-secondary);
+}
+
+.workshops-quote-form .form-control {
+  border-radius: 16px;
+  border: 1px solid rgba(37, 99, 235, 0.25);
+  padding: 0.9rem 1.1rem;
+}
+
+.workshops-quote-form .form-control:focus {
+  border-color: rgba(37, 99, 235, 0.55);
+  box-shadow: 0 0 0 0.25rem rgba(37, 99, 235, 0.12);
+}
+
+.workshops-faq .section-heading {
+  margin-bottom: 2rem;
+}
+
+.communication-note {
+  font-weight: 600;
+  color: var(--color-primary);
+  background: rgba(37, 99, 235, 0.08);
+  border-radius: 18px;
+  padding: 1.2rem 1.4rem;
+  border: 1px solid rgba(37, 99, 235, 0.16);
+}
+
+.faq-mini-accordion {
+  padding: 2.4rem 2.6rem;
+  border-radius: var(--radius-lg);
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+}
+
+.faq-mini-accordion .faq-item {
+  border: 1px solid rgba(37, 99, 235, 0.18);
+  border-radius: 18px;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.78);
+}
+
+.faq-mini-accordion .faq-toggle {
+  width: 100%;
+  padding: 1.1rem 1.4rem;
+  background: transparent;
+  border: none;
+  font-weight: 600;
+  font-size: 1rem;
+  color: var(--color-dark);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  text-align: left;
+}
+
+.faq-mini-accordion .faq-toggle .icon {
+  color: var(--color-primary);
+  font-size: 1.2rem;
+}
+
+.faq-mini-accordion .faq-content {
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height 0.35s ease, padding 0.35s ease;
+  padding: 0 1.4rem;
+  color: var(--color-muted);
+}
+
+.faq-mini-accordion .faq-content.show {
+  max-height: 240px;
+  padding: 0 1.4rem 1.2rem;
+}
+
+@media (max-width: 991.98px) {
+  .workshops-hero .hero-actions {
+    justify-content: flex-start;
+  }
+
+  .workshops-hero-card {
+    margin-top: 2rem;
+  }
+
+  .workshops-benefits__summary,
+  .workshops-benefits__card {
+    padding: 2.4rem 2.2rem;
+  }
+}
+
+@media (max-width: 767.98px) {
+  .workshop-card__image {
+    height: 200px;
+  }
+
+  .workshops-hero .hero-actions {
+    gap: 0.75rem;
+  }
+
+  .workshops-hero .hero-actions .improved-btn,
+  .workshops-hero .hero-actions .btn-secondary-outline {
+    width: 100%;
+  }
+
+  .list-check-inline {
+    gap: 0.6rem;
+  }
+}
+
+@media (max-width: 575.98px) {
+  .workshops-quote .quote-panel {
+    padding: 2.4rem 1.8rem;
+  }
+
+  .faq-mini-accordion {
+    padding: 2rem 1.6rem;
+  }
+}

--- a/faq.html
+++ b/faq.html
@@ -37,6 +37,7 @@
           <li class="nav-item"><a class="nav-link" href="index.html">Inicio</a></li>
           <li class="nav-item"><a class="nav-link" href="sobre-nosotros.html">Sobre Nosotros</a></li>
           <li class="nav-item"><a class="nav-link" href="contacto.html">Contacto</a></li>
+          <li class="nav-item"><a class="nav-link" href="talleres.html">Talleres y Educación</a></li>
           <li class="nav-item"><a class="nav-link" href="servicios.html">Servicios</a></li>
           <li class="nav-item"><a class="nav-link active" href="faq.html">FAQ</a></li>
         </ul>

--- a/index.html
+++ b/index.html
@@ -53,6 +53,9 @@
             <a class="nav-link" href="contacto.html">Contacto</a>
           </li>
           <li class="nav-item">
+            <a class="nav-link" href="talleres.html">Talleres y Educación</a>
+          </li>
+          <li class="nav-item">
             <a class="nav-link " href="servicios.html">Servicios</a>
           </li>
           <li class="nav-item">

--- a/js/contactform.js
+++ b/js/contactform.js
@@ -3,6 +3,7 @@ jQuery(document).ready(function($) {
 
   //Contact
   $('form.contactForm').submit(function() {
+    var isStubForm = $(this).data('stub') === true || $(this).attr('data-stub') === 'true';
     var f = $(this).find('.form-group'),
       ferror = false,
       emailExp = /^[^\s()<>@,;:\/]+@\w[\w\.-]+\.[a-z]{2,}$/i;
@@ -90,6 +91,14 @@ jQuery(document).ready(function($) {
     });
     if (ferror) return false;
     else var str = $(this).serialize();
+
+    if (isStubForm) {
+      $("#sendmessage").addClass("show");
+      $("#errormessage").removeClass("show");
+      $(this).find("input, textarea, select").val("");
+      console.info('TODO: Reemplazar stub del formulario con integración real.');
+      return false;
+    }
     var action = $(this).attr('action');
     if( ! action ) {
       action = 'contactform/contactform.php';

--- a/servicios.html
+++ b/servicios.html
@@ -37,6 +37,7 @@
           <li class="nav-item"><a class="nav-link" href="index.html">Inicio</a></li>
           <li class="nav-item"><a class="nav-link" href="sobre-nosotros.html">Sobre Nosotros</a></li>
           <li class="nav-item"><a class="nav-link" href="contacto.html">Contacto</a></li>
+          <li class="nav-item"><a class="nav-link" href="talleres.html">Talleres y Educación</a></li>
           <li class="nav-item"><a class="nav-link active" href="servicios.html">Servicios</a></li>
           <li class="nav-item"><a class="nav-link" href="faq.html">FAQ</a></li>
         </ul>

--- a/sobre-nosotros.html
+++ b/sobre-nosotros.html
@@ -38,6 +38,7 @@
           <li class="nav-item"><a class="nav-link" href="index.html">Inicio</a></li>
           <li class="nav-item"><a class="nav-link active" href="sobre-nosotros.html">Sobre Nosotros</a></li>
           <li class="nav-item"><a class="nav-link" href="contacto.html">Contacto</a></li>
+          <li class="nav-item"><a class="nav-link" href="talleres.html">Talleres y Educación</a></li>
           <li class="nav-item"><a class="nav-link" href="servicios.html">Servicios</a></li>
           <li class="nav-item"><a class="nav-link" href="faq.html">FAQ</a></li>
         </ul>

--- a/talleres.html
+++ b/talleres.html
@@ -1,0 +1,441 @@
+<!DOCTYPE html>
+<html lang="es">
+
+<head>
+  <meta charset="utf-8">
+  <title>Talleres y Educación para Empresas - Cle_Broker</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="keywords"
+    content="talleres empresariales, capacitaciones, comunicación, liderazgo, bienestar, innovación, cle_broker">
+  <meta name="description"
+    content="Impulsa el potencial de tu equipo con talleres prácticos de comunicación, liderazgo, bienestar e innovación diseñados por Cle_Broker." />
+  <meta property="og:title" content="Talleres y Educación para Empresas - Cle_Broker" />
+  <meta property="og:description"
+    content="Proyecta, innova y mejora con talleres empresariales en comunicación, liderazgo y bienestar." />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://www.clebroker.com/talleres" />
+  <meta property="og:image" content="img/1702.jpg" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Talleres y Educación para Empresas - Cle_Broker" />
+  <meta name="twitter:description"
+    content="Capacita a tu equipo con experiencias formativas enfocadas en comunicación, liderazgo e innovación." />
+  <meta name="twitter:image" content="img/1703.jpg" />
+  <link href="img/CLE_BROKER.png" rel="icon">
+  <link href="img/apple-touch-icon.png" rel="apple-touch-icon">
+  <link href="https://fonts.googleapis.com/css?family=Poppins:300,400,500,600,700" rel="stylesheet">
+  <link href="lib/bootstrap/css/bootstrap.min.css" rel="stylesheet">
+  <link href="lib/font-awesome/css/font-awesome.min.css" rel="stylesheet">
+  <link href="lib/animate/animate.min.css" rel="stylesheet">
+  <link href="lib/ionicons/css/ionicons.min.css" rel="stylesheet">
+  <link href="lib/owlcarousel/assets/owl.carousel.min.css" rel="stylesheet">
+  <link href="css/style.css" rel="stylesheet">
+  <link href="css/talleres.page.css" rel="stylesheet">
+  <link href="css/chatbot.widget.css" rel="stylesheet">
+</head>
+
+<body>
+  <div class="click-closed"></div>
+
+  <nav class="navbar navbar-default navbar-trans navbar-expand-lg fixed-top">
+    <div class="container">
+      <button class="navbar-toggler collapsed" type="button" data-toggle="collapse" data-target="#navbarDefault"
+        aria-controls="navbarDefault" aria-expanded="false" aria-label="Toggle navigation">
+        <span></span><span></span><span></span>
+      </button>
+      <a class="navbar-brand" href="index.html">
+        <img src="img/CLE_BROKER1.png" alt="Cle_Broker" style="height: 100px;">
+      </a>
+      <div class="navbar-collapse collapse justify-content-center" id="navbarDefault">
+        <ul class="navbar-nav">
+          <li class="nav-item"><a class="nav-link" href="index.html">Inicio</a></li>
+          <li class="nav-item"><a class="nav-link" href="sobre-nosotros.html">Sobre Nosotros</a></li>
+          <li class="nav-item"><a class="nav-link" href="contacto.html">Contacto</a></li>
+          <li class="nav-item"><a class="nav-link active" href="talleres.html">Talleres y Educación</a></li>
+          <li class="nav-item"><a class="nav-link" href="servicios.html">Servicios</a></li>
+          <li class="nav-item"><a class="nav-link" href="faq.html">FAQ</a></li>
+        </ul>
+      </div>
+    </div>
+  </nav>
+
+  <section class="page-hero workshops-hero bg-image" style="background-image: url(img/contact2.jpg);">
+    <div class="hero-overlay"></div>
+    <div class="container">
+      <div class="row align-items-center g-4">
+        <div class="col-lg-7">
+          <div class="hero-eyebrow"><i class="fa fa-lightbulb-o"></i> Talleres empresariales</div>
+          <h1 class="hero-title">Proyecta, innova, mejora.</h1>
+          <p class="hero-subtitle">Impulsa el potencial de tu equipo con talleres prácticos en Comunicación, Liderazgo y
+            Crecimiento Personal.</p>
+          <div class="hero-actions">
+            <a href="#temas" class="improved-btn improved-btn-primary">Explorar talleres (Presenciales)</a>
+            <a href="#cotizacion" class="btn-secondary-outline">Cotizar para empresas</a>
+            <a href="#cotizacion" class="improved-btn btn-ghost">Solicita información</a>
+          </div>
+          <div class="hero-metrics">
+            <div class="metric">
+              <strong>+45</strong>
+              <span>programas customizados</span>
+            </div>
+            <div class="metric">
+              <strong>97%</strong>
+              <span>equipos más comprometidos</span>
+            </div>
+            <div class="metric">
+              <strong>3</strong>
+              <span>formatos flexibles</span>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-5 d-none d-lg-block">
+          <div class="workshops-hero-card surface-card">
+            <span class="card-label">Experiencias transformadoras</span>
+            <h3>Cultura, innovación y bienestar en acción</h3>
+            <p>Facilitadores expertos guían sesiones vivenciales con herramientas aplicables desde el primer día.</p>
+            <ul class="list-check">
+              <li><i class="fa fa-check"></i> Diagnóstico previo y ajustes a la medida.</li>
+              <li><i class="fa fa-check"></i> Materiales de seguimiento y retos semanales.</li>
+              <li><i class="fa fa-check"></i> Evaluación de impacto y recomendaciones.</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <div class="breadcrumb-floating">
+        <nav aria-label="breadcrumb">
+          <ol class="breadcrumb">
+            <li class="breadcrumb-item"><a href="index.html">Inicio</a></li>
+            <li class="breadcrumb-item active" aria-current="page">Talleres y Educación</li>
+          </ol>
+        </nav>
+      </div>
+    </div>
+  </section>
+
+  <section class="section workshops-themes" id="temas">
+    <div class="container">
+      <div class="section-heading text-center">
+        <div class="eyebrow"><i class="ion-ios-people"></i> Temáticas clave</div>
+        <h2>Talleres diseñados para potenciar equipos de alto desempeño</h2>
+        <p>Selecciona la experiencia que responde al momento actual de tu organización y fortalece habilidades
+          humanas y digitales.</p>
+      </div>
+      <div class="row g-4">
+        <div class="col-md-6 col-lg-4">
+          <article class="workshop-card surface-card">
+            <div class="workshop-card__media">
+              <img src="img/1703.jpg" alt="Comunicación Asertiva en el Trabajo" class="workshop-card__image">
+            </div>
+            <div class="workshop-card__body">
+              <h3>Comunicación Asertiva en el Trabajo</h3>
+              <p>Mejora las conversaciones clave con herramientas de escucha activa, feedback empático y acuerdos
+                claros.</p>
+              <a href="#cotizacion" class="btn-secondary-outline">Más información</a>
+            </div>
+          </article>
+        </div>
+        <div class="col-md-6 col-lg-4">
+          <article class="workshop-card surface-card">
+            <div class="workshop-card__media">
+              <img src="img/apt5.jpg" alt="Liderazgo y Trabajo en Equipo" class="workshop-card__image">
+            </div>
+            <div class="workshop-card__body">
+              <h3>Liderazgo y Trabajo en Equipo</h3>
+              <p>Activa liderazgos colaborativos y fortalece la coordinación entre áreas con dinámicas de co-creación.</p>
+              <a href="#cotizacion" class="btn-secondary-outline">Más información</a>
+            </div>
+          </article>
+        </div>
+        <div class="col-md-6 col-lg-4">
+          <article class="workshop-card surface-card">
+            <div class="workshop-card__media">
+              <img src="img/apt4.jpg" alt="Gestión del Estrés y Bienestar Laboral" class="workshop-card__image">
+            </div>
+            <div class="workshop-card__body">
+              <h3>Gestión del Estrés y Bienestar Laboral</h3>
+              <p>Construye hábitos de autocuidado, protocolos de pausa activa y microprácticas de mindfulness corporativo.</p>
+              <a href="#cotizacion" class="btn-secondary-outline">Más información</a>
+            </div>
+          </article>
+        </div>
+        <div class="col-md-6 col-lg-4">
+          <article class="workshop-card surface-card">
+            <div class="workshop-card__media">
+              <img src="img/apt7.jpg" alt="Inteligencia Emocional aplicada a la Empresa" class="workshop-card__image">
+            </div>
+            <div class="workshop-card__body">
+              <h3>Inteligencia Emocional aplicada a la Empresa</h3>
+              <p>Desarrolla empatía, autogestión y resiliencia para tomar decisiones conscientes y cuidar el clima laboral.</p>
+              <a href="#cotizacion" class="btn-secondary-outline">Más información</a>
+            </div>
+          </article>
+        </div>
+        <div class="col-md-6 col-lg-4">
+          <article class="workshop-card surface-card">
+            <div class="workshop-card__media">
+              <img src="img/1702.jpg" alt="Innovación y Creatividad para Equipos" class="workshop-card__image">
+            </div>
+            <div class="workshop-card__body">
+              <h3>Innovación y Creatividad para Equipos</h3>
+              <p>Integra métodos ágiles, ideación guiada y prototipado rápido para impulsar soluciones de impacto.</p>
+              <a href="#cotizacion" class="btn-secondary-outline">Más información</a>
+            </div>
+          </article>
+        </div>
+        <div class="col-md-6 col-lg-4">
+          <article class="workshop-card surface-card">
+            <div class="workshop-card__media">
+              <img src="img/fq.jpg" alt="Actualidad en lo Digital" class="workshop-card__image">
+            </div>
+            <div class="workshop-card__body">
+              <h3>Actualidad en lo Digital</h3>
+              <p>Comprende tendencias digitales, herramientas colaborativas y estrategias para la transformación
+                tecnológica.</p>
+              <a href="#cotizacion" class="btn-secondary-outline">Más información</a>
+            </div>
+          </article>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="section workshops-benefits section-no-overlay" id="beneficios">
+    <div class="container">
+      <div class="row g-4 align-items-center">
+        <div class="col-lg-6">
+          <div class="surface-card workshops-benefits__card">
+            <div class="section-heading text-start">
+              <div class="eyebrow"><i class="ion-ios-checkmark"></i> Beneficios empresariales</div>
+              <h2>Equipos más motivados, conectados e innovadores</h2>
+              <p>Cada programa está diseñado para desarrollar habilidades prácticas que se reflejan en productividad y
+                bienestar sostenible.</p>
+            </div>
+            <ul class="list-check">
+              <li><i class="fa fa-check"></i> Equipos más motivados y orientados a resultados.</li>
+              <li><i class="fa fa-check"></i> Mejor comunicación interna y feedback continuo.</li>
+              <li><i class="fa fa-check"></i> Mayor productividad con metodologías claras.</li>
+              <li><i class="fa fa-check"></i> Menos conflictos y ambientes colaborativos.</li>
+            </ul>
+          </div>
+        </div>
+        <div class="col-lg-6">
+          <div class="workshops-benefits__summary surface-card">
+            <h3>Invertir en el talento transforma la cultura</h3>
+            <p>Vive una experiencia transformadora con facilitadores certificados, dinámicas inmersivas y retos que
+              conectan la teoría con la práctica. Impulsa la innovación, fortalece habilidades blandas y prioriza el
+              bienestar integral de cada colaborador.</p>
+            <div class="benefits-metrics">
+              <div>
+                <strong>85%</strong>
+                <span>equipos aplican acciones en 30 días</span>
+              </div>
+              <div>
+                <strong>4.8/5</strong>
+                <span>satisfacción de participantes</span>
+              </div>
+              <div>
+                <strong>+20</strong>
+                <span>sectores acompañados</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="section workshops-quote" id="cotizacion">
+    <div class="container">
+      <div class="quote-panel surface-card">
+        <div class="row g-4 align-items-center">
+          <div class="col-lg-6">
+            <div class="section-heading text-start">
+              <div class="eyebrow"><i class="ion-ios-compose"></i> Formulario de cotización</div>
+              <h2>Recibe una propuesta adaptada a tu equipo</h2>
+              <p>Completa los datos y te contactaremos en menos de 24 horas para diseñar la experiencia ideal.</p>
+            </div>
+            <ul class="list-check list-check-inline">
+              <li><i class="fa fa-check"></i> Formatos presenciales, virtuales e híbridos.</li>
+              <li><i class="fa fa-check"></i> Seguimiento posterior a la sesión.</li>
+              <li><i class="fa fa-check"></i> Material de apoyo descargable.</li>
+            </ul>
+          </div>
+          <div class="col-lg-6">
+            <form class="form-a contactForm workshops-quote-form" method="post" role="form" action="" data-stub="true">
+              <div id="sendmessage">¡Tu mensaje ha sido enviado! Te contactaremos pronto.</div>
+              <div id="errormessage"></div>
+              <div class="row g-3">
+                <div class="col-12">
+                  <div class="form-group">
+                    <label for="quoteName">Nombre</label>
+                    <input type="text" name="name" class="form-control form-control-lg form-control-a" id="quoteName"
+                      placeholder="Tu nombre completo *" required data-rule="required"
+                      data-msg="Por favor ingresa tu nombre">
+                    <div class="validation"></div>
+                  </div>
+                </div>
+                <div class="col-12">
+                  <div class="form-group">
+                    <label for="quoteWhatsapp">WhatsApp</label>
+                    <input type="tel" name="phone" class="form-control form-control-lg form-control-a"
+                      id="quoteWhatsapp" placeholder="Número de WhatsApp *" required data-rule="required"
+                      data-msg="Indícanos un número de contacto">
+                    <div class="validation"></div>
+                  </div>
+                </div>
+                <div class="col-12">
+                  <div class="form-group">
+                    <label for="quoteTopic">Tema de interés</label>
+                    <select name="subject" id="quoteTopic" class="form-control form-control-lg form-control-a" required
+                      data-rule="required" data-msg="Selecciona un tema">
+                      <option value="">Selecciona una opción</option>
+                      <option value="comunicacion-asertiva">Comunicación Asertiva en el Trabajo</option>
+                      <option value="liderazgo-trabajo-equipo">Liderazgo y Trabajo en Equipo</option>
+                      <option value="gestion-estres">Gestión del Estrés y Bienestar Laboral</option>
+                      <option value="inteligencia-emocional">Inteligencia Emocional aplicada a la Empresa</option>
+                      <option value="innovacion-creatividad">Innovación y Creatividad para Equipos</option>
+                      <option value="actualidad-digital">Actualidad en lo Digital</option>
+                    </select>
+                    <div class="validation"></div>
+                  </div>
+                </div>
+                <div class="col-12 text-start">
+                  <button type="submit" class="improved-btn improved-btn-primary">Recibir mi cotización ahora</button>
+                </div>
+              </div>
+            </form>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="section workshops-faq section-no-overlay">
+    <div class="container">
+      <div class="row g-4 align-items-start">
+        <div class="col-lg-6">
+          <div class="section-heading text-start">
+            <div class="eyebrow"><i class="ion-ios-help"></i> Preguntas frecuentes</div>
+            <h2>Resolvemos inquietudes antes de tu taller</h2>
+            <p>Nuestro equipo responde rápidamente para garantizar que cada sesión se alinee con tus objetivos.</p>
+          </div>
+          <p class="communication-note">La Comunicación en su entorno de trabajo es el punto de partida para
+            transformar culturas y alcanzar resultados sostenibles.</p>
+        </div>
+        <div class="col-lg-6">
+          <div class="faq-mini-accordion surface-card">
+            <div class="faq-item">
+              <button class="faq-toggle" type="button" aria-expanded="true">
+                ¿Cuánto dura cada taller?
+                <span class="icon"><i class="ion-ios-arrow-down"></i></span>
+              </button>
+              <div class="faq-content show">
+                La duración estándar es de 3 a 4 horas con módulos adaptables según la profundidad requerida por tu
+                empresa.
+              </div>
+            </div>
+            <div class="faq-item">
+              <button class="faq-toggle" type="button" aria-expanded="false">
+                ¿Pueden desarrollar contenidos a la medida?
+                <span class="icon"><i class="ion-ios-arrow-down"></i></span>
+              </button>
+              <div class="faq-content">
+                Sí. Partimos de un diagnóstico breve para co-crear actividades, ejemplos y recursos alineados a tus
+                retos y cultura.
+              </div>
+            </div>
+            <div class="faq-item">
+              <button class="faq-toggle" type="button" aria-expanded="false">
+                ¿Ofrecen modalidades híbridas o virtuales?
+                <span class="icon"><i class="ion-ios-arrow-down"></i></span>
+              </button>
+              <div class="faq-content">
+                Ofrecemos talleres presenciales, virtuales e híbridos apoyados con herramientas colaborativas y material
+                descargable.
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="section-footer">
+    <div class="container">
+      <div class="row">
+        <div class="col-sm-12 col-md-4">
+          <div class="widget-a">
+            <div class="w-header-a">
+              <h3 class="w-title-a text-brand">Cle_Broker</h3>
+            </div>
+            <div class="w-body-a">
+              <p class="w-text-a color-text-a">
+                Encuentra tu hogar ideal. Venta y arriendo de casas, apartamentos y oficinas.
+              </p>
+            </div>
+            <div class="w-footer-a">
+              <ul class="list-unstyled">
+                <li class="color-a">
+                  <span class="color-text-a">Email: </span> cle23gallo@gmail.com
+                </li>
+                <li class="color-a">
+                  <span class="color-text-a">Teléfono: </span> +57 300 3137 616
+                </li>
+                <li class="color-a">
+                  <span class="color-text-a">Dirección: </span> Bogotá, Colombia.
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <footer>
+    <div class="container">
+      <div class="row">
+        <div class="col-md-12">
+          <div class="copyright-footer">
+            <p class="copyright color-text-a">
+              &copy; Copyright
+              <span class="color-a">Cle_Broker</span> Todos los derechos reservados. 2025
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </footer>
+
+  <a href="#" class="back-to-top"><i class="fa fa-chevron-up"></i></a>
+  <div id="preloader"></div>
+
+  <script src="lib/jquery/jquery.min.js"></script>
+  <script src="lib/jquery/jquery-migrate.min.js"></script>
+  <script src="lib/popper/popper.min.js"></script>
+  <script src="lib/bootstrap/js/bootstrap.min.js"></script>
+  <script src="lib/easing/easing.min.js"></script>
+  <script src="lib/owlcarousel/owl.carousel.min.js"></script>
+  <script src="lib/scrollreveal/scrollreveal.min.js"></script>
+  <script src="js/contactform.js"></script>
+  <script src="js/main.js"></script>
+  <script>window.CHATBOT_CONFIG = window.CHATBOT_CONFIG || {};</script>
+  <script src="js/chatbot.widget.js"></script>
+  <script>
+    (function () {
+      var toggles = document.querySelectorAll('.faq-mini-accordion .faq-toggle');
+      toggles.forEach(function (toggle) {
+        toggle.addEventListener('click', function () {
+          var expanded = this.getAttribute('aria-expanded') === 'true';
+          this.setAttribute('aria-expanded', !expanded);
+          var content = this.nextElementSibling;
+          if (expanded) {
+            content.classList.remove('show');
+          } else {
+            content.classList.add('show');
+          }
+        });
+      });
+    })();
+  </script>
+</body>
+
+</html>


### PR DESCRIPTION
## Summary
- add the new Talleres y Educación page with hero messaging, themed workshop cards, benefits, quote form, and FAQ content
- create dedicated styling for the workshops page and tweak the contact form script to support a stubbed submission flow
- expose the Talleres y Educación route across the site navigation and document the new page in the README

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68e6a90bbf0c832aa1ca6dc6611acd01