### PR TITLE
Make hero headings white and update chatbot WhatsApp actions

### DIFF
--- a/css/contacto.page.css
+++ b/css/contacto.page.css
@@ -5,6 +5,10 @@
   opacity: 0.92;
 }
 
+.contact-hero .hero-title {
+  color: #ffffff;
+}
+
 .contact-hero-card {
   padding: 2.4rem 2.6rem;
   border-radius: var(--radius-lg);

--- a/css/faq.page.css
+++ b/css/faq.page.css
@@ -5,6 +5,10 @@
   opacity: 0.94;
 }
 
+.faq-hero .hero-title {
+  color: #ffffff;
+}
+
 .faq-hero-card {
   padding: 2.6rem 2.8rem;
   border-radius: var(--radius-lg);

--- a/css/servicios.page.css
+++ b/css/servicios.page.css
@@ -5,6 +5,10 @@
   opacity: 0.94;
 }
 
+.services-hero .hero-title {
+  color: #ffffff;
+}
+
 .services-hero-card {
   padding: 2.6rem 2.8rem;
   border-radius: var(--radius-lg);

--- a/css/talleres.page.css
+++ b/css/talleres.page.css
@@ -2,6 +2,10 @@
   background: linear-gradient(115deg, rgba(15, 23, 42, 0.9) 8%, rgba(37, 99, 235, 0.72) 60%, rgba(124, 58, 237, 0.68) 100%);
 }
 
+.workshops-hero .hero-title {
+  color: #ffffff;
+}
+
 .workshops-hero .hero-actions {
   display: flex;
   flex-wrap: wrap;

--- a/js/chatbot.widget.js
+++ b/js/chatbot.widget.js
@@ -157,7 +157,7 @@
 
       // --- versión sin redirecciones ---
       f.querySelector('[data-action="whatsapp"]').addEventListener("click", () => {
-        bot.msg(`Puedes escribirnos por <strong>WhatsApp</strong>:<br>${CFG.whatsappURL}`);
+        window.open(`https://api.whatsapp.com/send?phone=${CFG.whatsappURL}`, "_blank", "noopener");
       });
 
       f.querySelector('[data-action="email"]').addEventListener("click", () => {
@@ -195,7 +195,10 @@
       bot.choices([
         { label: "Ver Propiedades", onClick: () => window.open(CFG.nav.propiedades, "_blank") },
         { label: "Agendar visita", onClick: () => bot.formLead({ message: "Quiero agendar visita" }) },
-        { label: "WhatsApp", onClick: () => bot.msg(`WhatsApp: ${CFG.whatsappURL}`) },
+        {
+          label: "WhatsApp",
+          onClick: () => window.open(`https://api.whatsapp.com/send?phone=${CFG.whatsappURL}`, "_blank", "noopener"),
+        },
         { label: "Llamar", onClick: () => bot.msg(`Teléfono: ${CFG.phoneDisplay}`) },
         { label: "Horarios", onClick: () => bot.showHours() },
         { label: "Email", onClick: () => bot.msg(`Correo: ${CFG.email}`) },


### PR DESCRIPTION
## Summary
- set the hero heading color to white on the contacto, talleres, servicios, and FAQ pages for improved contrast
- change the chatbot WhatsApp buttons to open the WhatsApp API in a new tab

## Testing
- No automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e719d7e004832a867f5669c979da96