### PR TITLE
Render featured property details inside chatbot

### DIFF
--- a/css/chatbot.widget.css
+++ b/css/chatbot.widget.css
@@ -301,6 +301,113 @@
   border-radius: 10px;
 }
 
+.cbot-property {
+  display: grid;
+  gap: 12px;
+}
+
+.cbot-property-media {
+  position: relative;
+  border-radius: 14px;
+  overflow: hidden;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+}
+
+.cbot-property-media img {
+  width: 100%;
+  height: 180px;
+  object-fit: cover;
+  display: block;
+}
+
+.cbot-property-badge {
+  position: absolute;
+  top: 12px;
+  left: 12px;
+  background: var(--cbot-accent);
+  color: #fff;
+  font-size: 12px;
+  letter-spacing: .04em;
+  padding: 4px 10px;
+  border-radius: 999px;
+  text-transform: uppercase;
+  box-shadow: 0 6px 16px rgba(18, 83, 48, 0.35);
+}
+
+.cbot-property-content h3 {
+  font-size: 16px;
+  margin: 0;
+}
+
+.cbot-property-location {
+  margin: 4px 0 8px;
+  font-size: 13px;
+  opacity: .85;
+}
+
+.cbot-property-summary {
+  font-size: 13px;
+  line-height: 1.5;
+  margin-bottom: 10px;
+}
+
+.cbot-property-price {
+  font-size: 18px;
+  font-weight: 700;
+  margin-bottom: 10px;
+  color: var(--cbot-accent);
+}
+
+.cbot-property-features {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 12px;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.cbot-property-features li {
+  background: var(--cbot-surface);
+  border-radius: 10px;
+  padding: 8px 10px;
+  font-size: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  border: 1px solid var(--cbot-border);
+}
+
+.cbot-property-features li span {
+  text-transform: uppercase;
+  letter-spacing: .05em;
+  opacity: .7;
+}
+
+.cbot-property-features li strong {
+  font-size: 13px;
+}
+
+.cbot-property-cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 16px;
+  border-radius: 999px;
+  font-size: 13px;
+  font-weight: 600;
+  text-decoration: none;
+  color: #fff;
+  background: var(--cbot-accent-2);
+  box-shadow: 0 8px 18px rgba(16, 185, 129, 0.25);
+  transition: transform .2s ease, box-shadow .2s ease;
+}
+
+.cbot-property-cta:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 20px rgba(16, 185, 129, 0.3);
+}
+
 @media (max-width: 480px) {
   .cbot-panel {
     right: 12px;

--- a/css/contacto.page.css
+++ b/css/contacto.page.css
@@ -5,6 +5,10 @@
   opacity: 0.92;
 }
 
+.contact-hero .hero-title {
+  color: #ffffff;
+}
+
 .contact-hero-card {
   padding: 2.4rem 2.6rem;
   border-radius: var(--radius-lg);

--- a/css/faq.page.css
+++ b/css/faq.page.css
@@ -5,6 +5,10 @@
   opacity: 0.94;
 }
 
+.faq-hero .hero-title {
+  color: #ffffff;
+}
+
 .faq-hero-card {
   padding: 2.6rem 2.8rem;
   border-radius: var(--radius-lg);

--- a/css/servicios.page.css
+++ b/css/servicios.page.css
@@ -5,6 +5,10 @@
   opacity: 0.94;
 }
 
+.services-hero .hero-title {
+  color: #ffffff;
+}
+
 .services-hero-card {
   padding: 2.6rem 2.8rem;
   border-radius: var(--radius-lg);

--- a/css/sobre-nosotros.page.css
+++ b/css/sobre-nosotros.page.css
@@ -5,6 +5,12 @@
   opacity: 0.94;
 }
 
+.about-hero .hero-eyebrow,
+.about-hero .hero-title,
+.about-hero .hero-subtitle {
+  color: #ffffff;
+}
+
 .about-hero-card {
   padding: 2.6rem 2.8rem;
   border-radius: var(--radius-lg);

--- a/css/talleres.page.css
+++ b/css/talleres.page.css
@@ -2,6 +2,10 @@
   background: linear-gradient(115deg, rgba(15, 23, 42, 0.9) 8%, rgba(37, 99, 235, 0.72) 60%, rgba(124, 58, 237, 0.68) 100%);
 }
 
+.workshops-hero .hero-title {
+  color: #ffffff;
+}
+
 .workshops-hero .hero-actions {
   display: flex;
   flex-wrap: wrap;

--- a/js/chatbot.widget.js
+++ b/js/chatbot.widget.js
@@ -18,11 +18,44 @@
       contacto: "/contacto.html",
       servicios: "/servicios.html",
       faq: "/faq.html",
-      propiedades: "/servicios.html"
+      propiedades: "/servicios.html#propiedades-destacadas"
     },
     leadWebhook: "", // opcional backend
     consentText: "Acepto el tratamiento de datos para ser contactado."
   };
+
+  const PROPERTIES = [
+    {
+      id: "apto-170",
+      title: "Apartamento Calle 170 - Bogotá",
+      location: "Calle 170, Usaquén",
+      price: 680000000,
+      area: "280 m²",
+      beds: 4,
+      baths: 3,
+      parking: 2,
+      badge: "Destacado",
+      image: "img/1703.jpg",
+      summary: "Dúplex con terraza privada, iluminación natural y acabados premium.",
+      ctaLabel: "Solicitar información",
+      ctaHref: "contacto.html"
+    },
+    {
+      id: "apto-cedritos",
+      title: "Apartamento 2 - Bogotá",
+      location: "Cedritos, Bogotá",
+      price: 280800000,
+      area: "85 m²",
+      beds: 2,
+      baths: 2,
+      parking: 1,
+      badge: "Nuevo",
+      image: "img/apt7.jpg",
+      summary: "Apartamento moderno listo para entrega, ideal para inversión o primera vivienda.",
+      ctaLabel: "Quiero visitar",
+      ctaHref: "contacto.html"
+    }
+  ];
 
   // ============== HTML ==============
   const html = `
@@ -73,6 +106,7 @@
     return Math.round(val);
   };
   const sanitize = (s) => s.replace(/[<>]/g, "");
+  const featuredPropertiesUrl = new URL(CFG.nav.propiedades, window.location.origin);
 
   // ============== VIEW HELPERS ==============
   const bot = {
@@ -157,7 +191,7 @@
 
       // --- versión sin redirecciones ---
       f.querySelector('[data-action="whatsapp"]').addEventListener("click", () => {
-        bot.msg(`Puedes escribirnos por <strong>WhatsApp</strong>:<br>${CFG.whatsappURL}`);
+        window.open(`https://api.whatsapp.com/send?phone=${CFG.whatsappURL}`, "_blank", "noopener");
       });
 
       f.querySelector('[data-action="email"]').addEventListener("click", () => {
@@ -184,18 +218,49 @@
     showNav() {
       bot.msg(`Navega rápido:`);
       const items = [
-        { label: "Propiedades", onClick: () => window.open(CFG.nav.propiedades, "_blank") },
+        { label: "Propiedades", onClick: () => window.open(featuredPropertiesUrl.href, "_blank") },
         { label: "Servicios", onClick: () => window.open(CFG.nav.servicios, "_blank") },
         { label: "FAQ", onClick: () => window.open(CFG.nav.faq, "_blank") },
         { label: "Contacto", onClick: () => window.open(CFG.nav.contacto, "_blank") },
       ];
       bot.choices(items);
     },
+    showProperties() {
+      bot.msg(`<strong>Propiedades destacadas disponibles</strong><br/>Explora opciones listas para agendar visita:`);
+      PROPERTIES.forEach((prop) => {
+        const features = [
+          { label: "Área", value: prop.area },
+          { label: "Habitaciones", value: prop.beds },
+          { label: "Baños", value: prop.baths },
+          { label: "Parqueaderos", value: prop.parking }
+        ].map((f) => `<li><span>${f.label}</span><strong>${f.value}</strong></li>`).join("");
+        bot.msg(`
+          <article class="cbot-property" data-id="${prop.id}">
+            <div class="cbot-property-media">
+              ${prop.badge ? `<span class="cbot-property-badge">${prop.badge}</span>` : ""}
+              ${prop.image ? `<img src="${prop.image}" alt="${prop.title}">` : ""}
+            </div>
+            <div class="cbot-property-content">
+              <h3>${prop.title}</h3>
+              <p class="cbot-property-location">📍 ${prop.location}</p>
+              <p class="cbot-property-summary">${prop.summary}</p>
+              <div class="cbot-property-price">${fmtCurrency(prop.price)}</div>
+              <ul class="cbot-property-features">${features}</ul>
+              <a class="cbot-property-cta" href="${prop.ctaHref}" target="_blank" rel="noopener">${prop.ctaLabel}</a>
+            </div>
+          </article>
+        `.trim());
+      });
+      bot.msg(`¿Te interesa alguna? Puedo agendar una visita o enviarte más alternativas.`);
+    },
     quickActions() {
       bot.choices([
-        { label: "Ver Propiedades", onClick: () => window.open(CFG.nav.propiedades, "_blank") },
+        { label: "Propiedades", onClick: () => bot.showProperties() },
         { label: "Agendar visita", onClick: () => bot.formLead({ message: "Quiero agendar visita" }) },
-        { label: "WhatsApp", onClick: () => bot.msg(`WhatsApp: ${CFG.whatsappURL}`) },
+        {
+          label: "WhatsApp",
+          onClick: () => window.open(`https://api.whatsapp.com/send?phone=${CFG.whatsappURL}`, "_blank", "noopener"),
+        },
         { label: "Llamar", onClick: () => bot.msg(`Teléfono: ${CFG.phoneDisplay}`) },
         { label: "Horarios", onClick: () => bot.showHours() },
         { label: "Email", onClick: () => bot.msg(`Correo: ${CFG.email}`) },
@@ -207,8 +272,7 @@
   function route(textRaw) {
     const text = textRaw.toLowerCase();
     if (/(propiedad|propiedades|inmueble|apartamento|casa|oficina)/.test(text)) {
-      bot.msg("Abro el listado de propiedades.");
-      window.open(CFG.nav.propiedades, "_blank");
+      bot.showProperties();
       return;
     }
     if (/(arriendo|arrendar|renta)/.test(text)) {

--- a/servicios.html
+++ b/servicios.html
@@ -187,7 +187,7 @@
     </div>
   </section>
 
-  <section class="section services-showcase">
+  <section id="propiedades-destacadas" class="section services-showcase">
     <div class="container">
       <div class="section-heading">
         <div class="eyebrow"><i class="ion-ios-home"></i> Portafolio vivo</div>


### PR DESCRIPTION
## Summary
- replace the chatbot "Ver Propiedades" quick action with a "Propiedades" action that lists featured homes directly in the conversation
- add a featured property catalog and intent handling so property questions respond with rich cards instead of redirecting away from the chatbot
- style the chatbot property cards with images, badges, key facts, and contact calls to action for a polished presentation

## Testing
- Not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e719d7e004832a867f5669c979da96