### PR TITLE
Add Express/Prisma backend for CLE_BROKER forms and content

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,24 @@
+# Variables esenciales
+NODE_ENV=development
+PORT=3000
+DATABASE_URL=postgresql://postgres:postgres@postgres:5432/cle_broker
+JWT_SECRET=supersecret
+JWT_EXPIRES_IN=15m
+ADMIN_EMAIL=admin@example.com
+ADMIN_PASSWORD=Admin123!
+
+# Configuración SMTP
+SMTP_HOST=smtp.mailtrap.io
+SMTP_PORT=587
+SMTP_USER=usuario
+SMTP_PASS=clave
+SMTP_FROM=KayrosGo <no-reply@kayrosgo.test>
+
+# Seguridad
+BASE_URL=http://localhost:3000
+CORS_ORIGIN=http://localhost:5173
+RATE_LIMIT_WINDOW_MS=900000
+RATE_LIMIT_MAX=100
+
+# Opcional
+PUBLIC_CONTACT_EMAIL=contacto@kayrosgo.test

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+node_modules
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*
+.env
+.env.local
+.env.*.local
+dist
+coverage
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm install --frozen-lockfile || npm install
+COPY tsconfig.json tsconfig.build.json jest.config.ts ./
+COPY prisma ./prisma
+COPY migrations ./migrations
+COPY src ./src
+RUN npx prisma generate
+RUN npm run build
+
+FROM node:20-alpine
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=builder /app/package.json ./
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/prisma ./prisma
+COPY --from=builder /app/migrations ./migrations
+CMD ["node", "dist/server.js"]

--- a/README.md
+++ b/README.md
@@ -75,3 +75,7 @@ Puedes adaptar fácilmente el proyecto según tus necesidades:
 * **Estilos:** modifica los colores, tipografías y tamaños en `css/estilos.css`.
 * **Scripts:** agrega o ajusta funciones en `js/main.js` para ampliar interactividad.
 * **Logos e íconos:** reemplaza los archivos en `img/` o usa SVG personalizados.
+
+## Backend API
+
+El repositorio ahora incluye un backend completo (carpeta `src/`) que expone endpoints REST para formularios, contenidos turísticos y autenticación administrativa sin modificar el frontend existente. Revisa [`README_BACKEND.md`](README_BACKEND.md) para detalles de despliegue, variables de entorno y ejemplos de integración mediante `fetch()`.

--- a/README_BACKEND.md
+++ b/README_BACKEND.md
@@ -1,0 +1,183 @@
+# KayrosGo / Cle_Broker – Backend API
+
+Backend modular en Node.js + Express con PostgreSQL y Prisma para manejar los formularios, contenidos turísticos y panel administrativo de KayrosGo / Cle_Broker.
+
+## Requisitos
+
+- Node.js 20+
+- PostgreSQL 14+
+- npm 9+
+
+## Configuración rápida
+
+1. Copia el archivo de variables de entorno:
+
+   ```bash
+   cp .env.example .env
+   ```
+
+2. Ajusta las variables obligatorias en `.env`:
+
+   - `DATABASE_URL=postgresql://usuario:clave@localhost:5432/cle_broker`
+   - `JWT_SECRET` (cadena segura)
+   - `ADMIN_EMAIL` y `ADMIN_PASSWORD`
+   - Parámetros SMTP (`SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS`)
+
+3. Instala dependencias y genera el cliente Prisma:
+
+   ```bash
+   npm install
+   npx prisma generate
+   ```
+
+4. Ejecuta las migraciones y datos iniciales:
+
+   ```bash
+   npx prisma migrate deploy
+   npm run seed
+   ```
+
+5. Inicia el servidor en desarrollo:
+
+   ```bash
+   npm run dev
+   ```
+
+El API queda disponible en `http://localhost:3000`.
+
+## Docker
+
+```bash
+docker-compose up --build -d
+```
+
+El servicio expone el API en el puerto `3000` y un contenedor PostgreSQL en `5432`.
+
+## Scripts disponibles
+
+| Comando            | Descripción                                     |
+|--------------------|-------------------------------------------------|
+| `npm run dev`      | Inicia el servidor con recarga automática        |
+| `npm run build`    | Compila TypeScript a JavaScript (`dist/`)        |
+| `npm start`        | Ejecuta el servidor compilado                    |
+| `npm run seed`     | Inserta usuario admin y contenido por defecto    |
+| `npm test`         | Ejecuta la suite de pruebas con Jest + Supertest |
+
+## Estructura de carpetas
+
+```
+src/
+├── core/            # utilidades transversales (env, prisma, mailer, logger)
+├── modules/
+│   ├── forms/       # formularios contacto y cotización
+│   ├── tourism/     # programas, beneficios y testimonios
+│   ├── cle_broker/  # servicios Cle_Broker
+│   ├── public/      # endpoint de propuesta consolidada
+│   └── users/       # autenticación administrativa
+├── routes/          # composición de rutas Express
+├── scripts/         # semilla inicial
+└── tests/           # pruebas (Jest + Supertest)
+```
+
+## Endpoints principales (`/api`)
+
+### Forms
+
+- `POST /forms/contacto`
+
+  ```bash
+  curl -X POST http://localhost:3000/api/forms/contacto \
+    -H "Content-Type: application/json" \
+    -d '{"nombre":"Ana","email":"ana@example.com","whatsapp":"+573001112233","destinoInteres":"Cancún"}'
+  ```
+
+- `POST /forms/cotizacion`
+
+  ```bash
+  curl -X POST http://localhost:3000/api/forms/cotizacion \
+    -H "Content-Type: application/json" \
+    -d '{"nombre":"Luis","email":"luis@example.com","whatsapp":"+573004445566","programaId":1,"mensaje":"Viaje familiar en julio"}'
+  ```
+
+### Tourism
+
+- `GET /tourism/programas?visible=true`
+- `POST /tourism/programas` *(requiere JWT)*
+- `GET /tourism/beneficios`
+- `GET /tourism/testimonios?visible=true`
+
+### Cle_Broker servicios
+
+- `GET /cle-broker/servicios?visible=true`
+- `POST /cle-broker/servicios` *(requiere JWT)*
+
+### Contenido público
+
+- `GET /public/propuesta` – Devuelve beneficios, programas destacados, proceso y servicios Cle_Broker listos para renderizar en el frontend.
+
+### Autenticación
+
+- `POST /auth/login` (email + password) → token JWT
+- `GET /auth/me` (header `Authorization: Bearer <token>`)
+
+### Salud
+
+- `GET /healthz`
+
+## Ejemplos `fetch` para integrar con el frontend existente
+
+```javascript
+// Enviar formulario de contacto
+async function enviarContacto(payload) {
+  const respuesta = await fetch('/api/forms/contacto', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
+  });
+  if (!respuesta.ok) throw new Error('No se pudo enviar el contacto');
+  return respuesta.json();
+}
+
+// Enviar solicitud de cotización
+async function enviarCotizacion(payload) {
+  const respuesta = await fetch('/api/forms/cotizacion', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
+  });
+  if (!respuesta.ok) throw new Error('No se pudo registrar la cotización');
+  return respuesta.json();
+}
+
+// Consumir contenido consolidado de propuesta
+async function cargarPropuesta() {
+  const respuesta = await fetch('/api/public/propuesta');
+  if (!respuesta.ok) throw new Error('No se pudo cargar la propuesta');
+  const data = await respuesta.json();
+  // data.beneficios, data.programasDestacados, data.serviciosCleBroker, data.proceso, data.testimonios, data.membresiaCodigo
+  return data;
+}
+```
+
+## Seguridad
+
+- Helmet + CORS restringido por `CORS_ORIGIN`
+- Rate limiting configurable (`RATE_LIMIT_*`)
+- JWT con expiración `JWT_EXPIRES_IN`
+- Auditoría básica en formularios (IP, user-agent y referer)
+
+## Pruebas
+
+La suite usa Jest + Supertest con mocks de Prisma y Nodemailer para validar rutas críticas (`forms`, `auth`, `tourism`). Ejecuta:
+
+```bash
+npm test
+```
+
+## Migraciones
+
+El archivo `migrations/0001_init.sql` replica la estructura del schema Prisma para despliegues en infraestructuras donde `prisma migrate` no está disponible.
+
+## Nota sobre correo
+
+El envío usa Nodemailer; en ambiente de pruebas (`NODE_ENV=test`) se aplica un transporte JSON (no se envían correos reales). Configura tus credenciales SMTP reales para producción.

--- a/README_BACKEND.md
+++ b/README_BACKEND.md
@@ -12,9 +12,17 @@ Backend modular en Node.js + Express con PostgreSQL y Prisma para manejar los fo
 
 1. Copia el archivo de variables de entorno:
 
-   ```bash
-   cp .env.example .env
-   ```
+   - **Linux / macOS:**
+
+     ```bash
+     cp .env.example .env
+     ```
+
+   - **Windows (PowerShell o CMD):**
+
+     ```powershell
+     copy .env.example .env
+     ```
 
 2. Ajusta las variables obligatorias en `.env`:
 
@@ -23,7 +31,7 @@ Backend modular en Node.js + Express con PostgreSQL y Prisma para manejar los fo
    - `ADMIN_EMAIL` y `ADMIN_PASSWORD`
    - Parámetros SMTP (`SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS`)
 
-3. Instala dependencias y genera el cliente Prisma:
+3. Instala dependencias y genera el cliente Prisma (los comandos son los mismos en Windows, macOS y Linux):
 
    ```bash
    npm install
@@ -37,11 +45,16 @@ Backend modular en Node.js + Express con PostgreSQL y Prisma para manejar los fo
    npm run seed
    ```
 
+   > 💡 En Windows puedes ejecutar estos comandos desde PowerShell, CMD o la terminal integrada de tu editor (VS Code). No es
+   > necesario usar WSL, aunque también es compatible.
+
 5. Inicia el servidor en desarrollo:
 
    ```bash
    npm run dev
    ```
+
+   Si prefieres un script dedicado en Windows, puedes usar `npm run dev` dentro de `run.bat` o crear un acceso directo.
 
 El API queda disponible en `http://localhost:3000`.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,27 @@
+version: '3.9'
+services:
+  db:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: cle_broker
+    volumes:
+      - cle_broker_pgdata:/var/lib/postgresql/data
+    ports:
+      - '5432:5432'
+  app:
+    build: .
+    depends_on:
+      - db
+    restart: unless-stopped
+    env_file:
+      - .env
+    environment:
+      DATABASE_URL: ${DATABASE_URL:-postgresql://postgres:postgres@db:5432/cle_broker}
+    ports:
+      - '3000:3000'
+    command: ['node', 'dist/server.js']
+volumes:
+  cle_broker_pgdata:

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,13 @@
+import type { Config } from 'jest';
+
+const config: Config = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/src/tests'],
+  setupFilesAfterEnv: ['<rootDir>/src/tests/setup.ts'],
+  moduleFileExtensions: ['ts', 'js', 'json'],
+  clearMocks: true,
+  coveragePathIgnorePatterns: ['/node_modules/', '/dist/']
+};
+
+export default config;

--- a/migrations/0001_init.sql
+++ b/migrations/0001_init.sql
@@ -1,0 +1,88 @@
+-- Prisma migration skeleton
+CREATE TABLE IF NOT EXISTS "Lead" (
+  "id" SERIAL PRIMARY KEY,
+  "nombre" TEXT NOT NULL,
+  "email" TEXT NOT NULL,
+  "whatsapp" TEXT NOT NULL,
+  "destinoInteres" TEXT,
+  "origenFormulario" TEXT NOT NULL,
+  "ipAddress" TEXT,
+  "userAgent" TEXT,
+  "referer" TEXT,
+  "createdAt" TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS "ProgramaTuristico" (
+  "id" SERIAL PRIMARY KEY,
+  "titulo" TEXT NOT NULL,
+  "descripcion" TEXT NOT NULL,
+  "dias" INTEGER NOT NULL,
+  "noches" INTEGER NOT NULL,
+  "allInclusive" BOOLEAN NOT NULL DEFAULT FALSE,
+  "destino" TEXT NOT NULL,
+  "rating" DOUBLE PRECISION,
+  "visible" BOOLEAN NOT NULL DEFAULT TRUE,
+  "createdAt" TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS "Cotizacion" (
+  "id" SERIAL PRIMARY KEY,
+  "leadId" INTEGER NOT NULL REFERENCES "Lead"("id") ON DELETE CASCADE,
+  "programaId" INTEGER REFERENCES "ProgramaTuristico"("id") ON DELETE SET NULL,
+  "mensaje" TEXT,
+  "notas" TEXT,
+  "estado" TEXT NOT NULL DEFAULT 'pendiente',
+  "createdAt" TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS "Beneficio" (
+  "id" SERIAL PRIMARY KEY,
+  "titulo" TEXT NOT NULL,
+  "detalle" TEXT NOT NULL,
+  "createdAt" TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS "Testimonio" (
+  "id" SERIAL PRIMARY KEY,
+  "autor" TEXT NOT NULL,
+  "contenido" TEXT NOT NULL,
+  "fuente" TEXT,
+  "visible" BOOLEAN NOT NULL DEFAULT TRUE,
+  "createdAt" TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS "ServicioCleBroker" (
+  "id" SERIAL PRIMARY KEY,
+  "titulo" TEXT NOT NULL,
+  "descripcionCorta" TEXT NOT NULL,
+  "descripcionLarga" TEXT,
+  "visible" BOOLEAN NOT NULL DEFAULT TRUE,
+  "orden" INTEGER NOT NULL DEFAULT 0,
+  "createdAt" TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TYPE "AdminUserRole" AS ENUM ('ADMIN', 'EDITOR');
+
+CREATE TABLE IF NOT EXISTS "AdminUser" (
+  "id" SERIAL PRIMARY KEY,
+  "email" TEXT NOT NULL UNIQUE,
+  "hash" TEXT NOT NULL,
+  "role" "AdminUserRole" NOT NULL DEFAULT 'ADMIN',
+  "createdAt" TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS "Config" (
+  "clave" TEXT PRIMARY KEY,
+  "valorJSON" TEXT NOT NULL,
+  "updatedAt" TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS "Lead_email_idx" ON "Lead" ("email");
+CREATE INDEX IF NOT EXISTS "Cotizacion_estado_idx" ON "Cotizacion" ("estado");
+CREATE INDEX IF NOT EXISTS "ProgramaTuristico_visible_idx" ON "ProgramaTuristico" ("visible");
+CREATE INDEX IF NOT EXISTS "ServicioCleBroker_visible_idx" ON "ServicioCleBroker" ("visible");

--- a/package.json
+++ b/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "cle_broker",
+  "version": "1.0.0",
+  "description": "Backend modular para CLE Broker con Express, Prisma y PostgreSQL.",
+  "main": "dist/server.js",
+  "type": "commonjs",
+  "scripts": {
+    "dev": "ts-node-dev --respawn --transpileOnly src/server.ts",
+    "build": "tsc --project tsconfig.build.json",
+    "start": "node dist/server.js",
+    "seed": "ts-node --transpile-only src/scripts/seed.ts",
+    "test": "jest --runInBand"
+  },
+  "dependencies": {
+    "@prisma/client": "5.16.1",
+    "bcryptjs": "2.4.3",
+    "cors": "2.8.5",
+    "dotenv": "16.4.5",
+    "express": "4.19.2",
+    "express-rate-limit": "7.2.0",
+    "helmet": "7.1.0",
+    "jsonwebtoken": "9.0.2",
+    "nodemailer": "6.9.13",
+    "pino": "9.3.2",
+    "pino-pretty": "11.2.2",
+    "zod": "3.23.8"
+  },
+  "devDependencies": {
+    "@types/bcryptjs": "2.4.6",
+    "@types/cors": "2.8.17",
+    "@types/express": "4.17.21",
+    "@types/helmet": "4.0.0",
+    "@types/jest": "29.5.12",
+    "@types/jsonwebtoken": "9.0.6",
+    "@types/node": "20.12.7",
+    "@types/nodemailer": "6.4.15",
+    "@types/pino": "8.1.5",
+    "@types/supertest": "2.0.16",
+    "jest": "29.7.0",
+    "prisma": "5.16.1",
+    "supertest": "6.3.4",
+    "ts-jest": "29.1.1",
+    "ts-node": "10.9.2",
+    "ts-node-dev": "2.0.0",
+    "typescript": "5.4.5"
+  }
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,98 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+enum AdminUserRole {
+  ADMIN
+  EDITOR
+}
+
+model Lead {
+  id               Int          @id @default(autoincrement())
+  nombre           String
+  email            String
+  whatsapp         String
+  destinoInteres   String?
+  origenFormulario String
+  ipAddress        String?
+  userAgent        String?
+  referer          String?
+  createdAt        DateTime     @default(now())
+  cotizaciones     Cotizacion[]
+}
+
+model Cotizacion {
+  id         Int               @id @default(autoincrement())
+  leadId     Int
+  lead       Lead              @relation(fields: [leadId], references: [id])
+  programaId Int?
+  programa   ProgramaTuristico? @relation(fields: [programaId], references: [id])
+  mensaje    String?
+  notas      String?
+  estado     String            @default("pendiente")
+  createdAt  DateTime          @default(now())
+}
+
+model ProgramaTuristico {
+  id           Int           @id @default(autoincrement())
+  titulo       String
+  descripcion  String
+  dias         Int
+  noches       Int
+  allInclusive Boolean       @default(false)
+  destino      String
+  rating       Float?
+  visible      Boolean       @default(true)
+  createdAt    DateTime      @default(now())
+  updatedAt    DateTime      @updatedAt
+  cotizaciones Cotizacion[]
+}
+
+model Beneficio {
+  id        Int      @id @default(autoincrement())
+  titulo    String
+  detalle   String
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+}
+
+model Testimonio {
+  id        Int      @id @default(autoincrement())
+  autor     String
+  contenido String
+  fuente    String?
+  visible   Boolean @default(true)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+}
+
+model ServicioCleBroker {
+  id               Int      @id @default(autoincrement())
+  titulo           String
+  descripcionCorta String
+  descripcionLarga String?
+  visible          Boolean @default(true)
+  orden            Int     @default(0)
+  createdAt        DateTime @default(now())
+  updatedAt        DateTime @updatedAt
+}
+
+model AdminUser {
+  id        Int           @id @default(autoincrement())
+  email     String        @unique
+  hash      String
+  role      AdminUserRole @default(ADMIN)
+  createdAt DateTime      @default(now())
+  updatedAt DateTime      @updatedAt
+}
+
+model Config {
+  clave     String  @id
+  valorJSON String
+  updatedAt DateTime @updatedAt
+}

--- a/src/core/env.ts
+++ b/src/core/env.ts
@@ -1,0 +1,33 @@
+import dotenv from 'dotenv';
+import { z } from 'zod';
+
+dotenv.config();
+
+const envSchema = z.object({
+  NODE_ENV: z.enum(['development', 'test', 'production']).default('development'),
+  PORT: z.string().default('3000'),
+  DATABASE_URL: z.string().min(1, 'DATABASE_URL es obligatorio'),
+  JWT_SECRET: z.string().min(1, 'JWT_SECRET es obligatorio'),
+  JWT_EXPIRES_IN: z.string().default('15m'),
+  ADMIN_EMAIL: z.string().email('ADMIN_EMAIL debe ser un email válido'),
+  ADMIN_PASSWORD: z.string().min(6, 'ADMIN_PASSWORD debe tener al menos 6 caracteres'),
+  SMTP_HOST: z.string().min(1),
+  SMTP_PORT: z.coerce.number().default(587),
+  SMTP_USER: z.string().min(1),
+  SMTP_PASS: z.string().min(1),
+  SMTP_SECURE: z
+    .string()
+    .optional()
+    .transform((val) => (val ? val === 'true' : undefined))
+    .optional(),
+  SMTP_FROM: z.string().email().optional(),
+  BASE_URL: z.string().min(1),
+  RATE_LIMIT_WINDOW_MS: z.coerce.number().optional(),
+  RATE_LIMIT_MAX: z.coerce.number().optional(),
+  CORS_ORIGIN: z.string().optional(),
+  PUBLIC_CONTACT_EMAIL: z.string().email().optional()
+});
+
+const env = envSchema.parse(process.env);
+
+export default env;

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -1,0 +1,34 @@
+import { NextFunction, Request, Response } from 'express';
+import logger from './logger';
+
+export class ApiError extends Error {
+  status: number;
+  details?: unknown;
+
+  constructor(status: number, message: string, details?: unknown) {
+    super(message);
+    this.status = status;
+    this.details = details;
+  }
+}
+
+export const notFoundHandler = (_req: Request, res: Response) => {
+  res.status(404).json({ message: 'Recurso no encontrado' });
+};
+
+export const errorHandler = (
+  err: Error,
+  _req: Request,
+  res: Response,
+  _next: NextFunction
+) => {
+  if (err instanceof ApiError) {
+    if (err.status >= 500) {
+      logger.error({ err, details: err.details }, err.message);
+    }
+    return res.status(err.status).json({ message: err.message, details: err.details });
+  }
+
+  logger.error({ err }, 'Error inesperado');
+  return res.status(500).json({ message: 'Error interno del servidor' });
+};

--- a/src/core/logger.ts
+++ b/src/core/logger.ts
@@ -1,0 +1,17 @@
+import pino from 'pino';
+import env from './env';
+
+const logger = pino({
+  transport:
+    env.NODE_ENV !== 'production'
+      ? {
+          target: 'pino-pretty',
+          options: {
+            colorize: true,
+            translateTime: 'SYS:standard'
+          }
+        }
+      : undefined
+});
+
+export default logger;

--- a/src/core/mailer.ts
+++ b/src/core/mailer.ts
@@ -1,0 +1,33 @@
+import nodemailer from 'nodemailer';
+import env from './env';
+import logger from './logger';
+
+const transporter = nodemailer.createTransport(
+  env.NODE_ENV === 'test'
+    ? { jsonTransport: true }
+    : {
+        host: env.SMTP_HOST,
+        port: env.SMTP_PORT,
+        secure: env.SMTP_SECURE ?? env.SMTP_PORT === 465,
+        auth: {
+          user: env.SMTP_USER,
+          pass: env.SMTP_PASS
+        }
+      }
+);
+
+export interface SendMailOptions {
+  to: string | string[];
+  subject: string;
+  html: string;
+}
+
+export async function sendMail(options: SendMailOptions) {
+  const from = env.SMTP_FROM ?? env.ADMIN_EMAIL;
+  const payload = { ...options, from };
+  const info = await transporter.sendMail(payload);
+  logger.info({ messageId: info.messageId, to: options.to }, 'Correo enviado');
+  return info;
+}
+
+export default transporter;

--- a/src/core/prisma.ts
+++ b/src/core/prisma.ts
@@ -1,0 +1,22 @@
+import { PrismaClient } from '@prisma/client';
+import env from './env';
+import logger from './logger';
+
+declare global {
+  // eslint-disable-next-line no-var
+  var prisma: PrismaClient | undefined;
+}
+
+const prismaClient = global.prisma || new PrismaClient({
+  log: env.NODE_ENV === 'development' ? ['query', 'error', 'warn'] : ['error']
+});
+
+if (env.NODE_ENV !== 'production') {
+  global.prisma = prismaClient;
+}
+
+prismaClient.$connect().catch((error) => {
+  logger.error({ error }, 'No se pudo conectar a la base de datos');
+});
+
+export default prismaClient;

--- a/src/core/rateLimit.ts
+++ b/src/core/rateLimit.ts
@@ -1,0 +1,15 @@
+import rateLimit from 'express-rate-limit';
+import env from './env';
+
+export function createRateLimiter(options?: { windowMs?: number; max?: number }) {
+  const windowMs = options?.windowMs ?? env.RATE_LIMIT_WINDOW_MS ?? 15 * 60 * 1000;
+  const max = options?.max ?? env.RATE_LIMIT_MAX ?? 100;
+
+  return rateLimit({
+    windowMs,
+    max,
+    standardHeaders: true,
+    legacyHeaders: false,
+    message: 'Demasiadas solicitudes, intenta nuevamente más tarde.'
+  });
+}

--- a/src/modules/cle_broker/cleBroker.router.ts
+++ b/src/modules/cle_broker/cleBroker.router.ts
@@ -1,0 +1,63 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import { requireAuth } from '../users/auth.middleware';
+import {
+  createServicio,
+  deleteServicio,
+  listServicios,
+  updateServicio
+} from './cleBroker.service';
+import { ApiError } from '../../core/errors';
+
+const router = Router();
+
+router.get('/servicios', async (req, res, next) => {
+  try {
+    const visible = req.query.visible === undefined ? undefined : req.query.visible === 'true';
+    const servicios = await listServicios(visible);
+    res.json({ servicios });
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.post('/servicios', requireAuth, async (req, res, next) => {
+  try {
+    const servicio = await createServicio(req.body);
+    res.status(201).json({ servicio });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      next(new ApiError(400, 'Datos inválidos', error.flatten()));
+      return;
+    }
+    next(error);
+  }
+});
+
+router.put('/servicios/:id', requireAuth, async (req, res, next) => {
+  try {
+    const id = Number(req.params.id);
+    if (Number.isNaN(id)) throw new ApiError(400, 'ID inválido');
+    const servicio = await updateServicio(id, req.body);
+    res.json({ servicio });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      next(new ApiError(400, 'Datos inválidos', error.flatten()));
+      return;
+    }
+    next(error);
+  }
+});
+
+router.delete('/servicios/:id', requireAuth, async (req, res, next) => {
+  try {
+    const id = Number(req.params.id);
+    if (Number.isNaN(id)) throw new ApiError(400, 'ID inválido');
+    await deleteServicio(id);
+    res.status(204).send();
+  } catch (error) {
+    next(error);
+  }
+});
+
+export default router;

--- a/src/modules/cle_broker/cleBroker.schemas.ts
+++ b/src/modules/cle_broker/cleBroker.schemas.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+export const servicioSchema = z.object({
+  titulo: z.string().min(3).max(160).trim(),
+  descripcionCorta: z.string().min(3).max(300).trim(),
+  descripcionLarga: z.string().min(3).max(2000).trim().optional(),
+  visible: z.boolean().default(true),
+  orden: z.number().int().nonnegative().default(0)
+});

--- a/src/modules/cle_broker/cleBroker.service.ts
+++ b/src/modules/cle_broker/cleBroker.service.ts
@@ -1,0 +1,32 @@
+import prisma from '../../core/prisma';
+import { servicioSchema } from './cleBroker.schemas';
+import { ApiError } from '../../core/errors';
+
+export async function listServicios(visible?: boolean) {
+  return prisma.servicioCleBroker.findMany({
+    where: visible === undefined ? {} : { visible },
+    orderBy: [{ orden: 'asc' }, { id: 'asc' }]
+  });
+}
+
+export async function createServicio(data: unknown) {
+  const parsed = servicioSchema.parse(data);
+  return prisma.servicioCleBroker.create({ data: parsed });
+}
+
+export async function updateServicio(id: number, data: unknown) {
+  const parsed = servicioSchema.partial().parse(data);
+  try {
+    return await prisma.servicioCleBroker.update({ where: { id }, data: parsed });
+  } catch (error) {
+    throw new ApiError(404, 'Servicio no encontrado');
+  }
+}
+
+export async function deleteServicio(id: number) {
+  try {
+    await prisma.servicioCleBroker.delete({ where: { id } });
+  } catch (error) {
+    throw new ApiError(404, 'Servicio no encontrado');
+  }
+}

--- a/src/modules/forms/forms.router.ts
+++ b/src/modules/forms/forms.router.ts
@@ -1,0 +1,44 @@
+import { Router } from 'express';
+import { ApiError } from '../../core/errors';
+import { createRateLimiter } from '../../core/rateLimit';
+import { handleContacto, handleCotizacion } from './forms.service';
+import { z } from 'zod';
+
+const router = Router();
+const limiter = createRateLimiter({ windowMs: 10 * 60 * 1000, max: 20 });
+
+router.post('/contacto', limiter, async (req, res, next) => {
+  try {
+    const lead = await handleContacto(req.body, {
+      ip: req.ip,
+      userAgent: req.get('user-agent') ?? undefined,
+      referer: req.get('referer') ?? undefined
+    });
+    res.status(201).json({ message: 'Contacto recibido', leadId: lead.id });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      next(new ApiError(400, 'Datos inválidos', error.flatten()));
+      return;
+    }
+    next(error);
+  }
+});
+
+router.post('/cotizacion', limiter, async (req, res, next) => {
+  try {
+    const cotizacion = await handleCotizacion(req.body, {
+      ip: req.ip,
+      userAgent: req.get('user-agent') ?? undefined,
+      referer: req.get('referer') ?? undefined
+    });
+    res.status(201).json({ message: 'Cotización creada', cotizacionId: cotizacion.id });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      next(new ApiError(400, 'Datos inválidos', error.flatten()));
+      return;
+    }
+    next(error);
+  }
+});
+
+export default router;

--- a/src/modules/forms/forms.schemas.ts
+++ b/src/modules/forms/forms.schemas.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod';
+
+export const contactoSchema = z.object({
+  nombre: z.string().min(2).max(120).trim(),
+  email: z.string().email().trim(),
+  whatsapp: z.string().min(6).max(30).trim(),
+  destinoInteres: z.string().max(180).trim().optional()
+});
+
+export const cotizacionSchema = z
+  .object({
+    leadId: z.number().int().positive().optional(),
+    nombre: z.string().min(2).max(120).trim().optional(),
+    email: z.string().email().trim().optional(),
+    whatsapp: z.string().min(6).max(30).trim().optional(),
+    destinoInteres: z.string().max(180).trim().optional(),
+    programaId: z.number().int().positive().optional(),
+    mensaje: z.string().max(500).trim().optional()
+  })
+  .refine((data) => data.leadId || (data.nombre && data.email && data.whatsapp), {
+    message: 'Debe proporcionar un leadId existente o los datos completos del lead',
+    path: ['lead']
+  });

--- a/src/modules/forms/forms.service.ts
+++ b/src/modules/forms/forms.service.ts
@@ -1,0 +1,120 @@
+import prisma from '../../core/prisma';
+import { sendMail } from '../../core/mailer';
+import env from '../../core/env';
+import { contactoSchema, cotizacionSchema } from './forms.schemas';
+import { ApiError } from '../../core/errors';
+
+export async function handleContacto(input: unknown, meta: { ip: string; userAgent?: string; referer?: string }) {
+  const data = contactoSchema.parse(input);
+
+  const lead = await prisma.lead.create({
+    data: {
+      nombre: data.nombre,
+      email: data.email,
+      whatsapp: data.whatsapp,
+      destinoInteres: data.destinoInteres,
+      origenFormulario: 'contacto',
+      ipAddress: meta.ip,
+      userAgent: meta.userAgent,
+      referer: meta.referer
+    }
+  });
+
+  await sendMail({
+    to: data.email,
+    subject: 'Hemos recibido tu solicitud - KayrosGo / Cle_Broker',
+    html: `
+      <p>Hola ${data.nombre},</p>
+      <p>Gracias por contactarnos. Uno de nuestros asesores de KayrosGo / Cle_Broker se comunicará contigo muy pronto.</p>
+      <p><strong>Detalles enviados:</strong></p>
+      <ul>
+        <li>Email: ${data.email}</li>
+        <li>WhatsApp: ${data.whatsapp}</li>
+        ${data.destinoInteres ? `<li>Destino de interés: ${data.destinoInteres}</li>` : ''}
+      </ul>
+      <p>¡Estamos listos para ayudarte a planear tu próximo viaje!</p>
+    `
+  });
+
+  return lead;
+}
+
+export async function handleCotizacion(
+  input: unknown,
+  meta: { ip: string; userAgent?: string; referer?: string }
+) {
+  const data = cotizacionSchema.parse(input);
+
+  let leadId = data.leadId ?? null;
+
+  if (!leadId) {
+    if (!data.nombre || !data.email || !data.whatsapp) {
+      throw new ApiError(400, 'Información de lead incompleta');
+    }
+
+    const newLead = await prisma.lead.create({
+      data: {
+        nombre: data.nombre,
+        email: data.email,
+        whatsapp: data.whatsapp,
+        destinoInteres: data.destinoInteres,
+        origenFormulario: 'cotizacion',
+        ipAddress: meta.ip,
+        userAgent: meta.userAgent,
+        referer: meta.referer
+      }
+    });
+    leadId = newLead.id;
+  }
+
+  const cotizacion = await prisma.cotizacion.create({
+    data: {
+      leadId,
+      programaId: data.programaId,
+      mensaje: data.mensaje,
+      notas: data.mensaje,
+      estado: 'pendiente'
+    },
+    include: {
+      lead: true,
+      programa: true
+    }
+  });
+
+  const lead = cotizacion.lead;
+  const programaTitulo = cotizacion.programa?.titulo;
+
+  const resumen = `
+    <ul>
+      <li>Nombre: ${lead.nombre}</li>
+      <li>Email: ${lead.email}</li>
+      <li>WhatsApp: ${lead.whatsapp}</li>
+      ${lead.destinoInteres ? `<li>Destino de interés: ${lead.destinoInteres}</li>` : ''}
+      ${programaTitulo ? `<li>Programa: ${programaTitulo}</li>` : ''}
+      ${data.mensaje ? `<li>Mensaje: ${data.mensaje}</li>` : ''}
+    </ul>
+  `;
+
+  await Promise.all([
+    sendMail({
+      to: lead.email,
+      subject: 'Solicitud de cotización recibida - KayrosGo / Cle_Broker',
+      html: `
+        <p>Hola ${lead.nombre},</p>
+        <p>Hemos recibido tu solicitud de cotización. Nuestro equipo se pondrá en contacto contigo muy pronto.</p>
+        <p><strong>Resumen:</strong></p>
+        ${resumen}
+      `
+    }),
+    sendMail({
+      to: env.ADMIN_EMAIL,
+      subject: 'Nueva solicitud de cotización',
+      html: `
+        <p>Se registró una nueva cotización en KayrosGo / Cle_Broker.</p>
+        ${resumen}
+      `
+    })
+  ]);
+
+  return cotizacion;
+}

--- a/src/modules/public/public.router.ts
+++ b/src/modules/public/public.router.ts
@@ -1,0 +1,56 @@
+import { Router } from 'express';
+import prisma from '../../core/prisma';
+
+const router = Router();
+
+function safeParseJSON<T>(value?: string): T | undefined {
+  if (!value) return undefined;
+  try {
+    return JSON.parse(value) as T;
+  } catch (error) {
+    return undefined;
+  }
+}
+
+router.get('/propuesta', async (_req, res, next) => {
+  try {
+    const [beneficios, programas, testimonios, servicios, configs] = await Promise.all([
+      prisma.beneficio.findMany({ orderBy: { id: 'asc' } }),
+      prisma.programaTuristico.findMany({ where: { visible: true }, orderBy: { id: 'asc' }, take: 6 }),
+      prisma.testimonio.findMany({ where: { visible: true }, orderBy: { id: 'asc' } }),
+      prisma.servicioCleBroker.findMany({ where: { visible: true }, orderBy: [{ orden: 'asc' }, { id: 'asc' }] }),
+      prisma.config.findMany({ where: { clave: { in: ['membresiaCodigo', 'propuestaProceso'] } } })
+    ]);
+
+    const configMap = Object.fromEntries(configs.map((item) => [item.clave, item.valorJSON]));
+
+    const proceso =
+      safeParseJSON<{ titulo: string; descripcion: string }[]>(configMap.propuestaProceso) ?? [
+        { titulo: 'Paso 1', descripcion: 'Elige tu programa' },
+        { titulo: 'Paso 2', descripcion: 'Recibe una cotización oficial con respaldo' },
+        { titulo: 'Paso 3', descripcion: 'Viaja con tranquilidad' }
+      ];
+
+    const membresiaCodigo = safeParseJSON<string>(configMap.membresiaCodigo) ?? 'R9025';
+
+    const propuesta = {
+      beneficios,
+      programasDestacados: programas,
+      testimonios,
+      serviciosCleBroker: servicios,
+      proceso,
+      mensajesClave: {
+        accesoPreciosPreferenciales: 'Acceso a precios preferenciales',
+        asesoriaPersonalizada: 'Asesoría personalizada',
+        respaldoOficial: 'Respaldo oficial'
+      },
+      membresiaCodigo
+    };
+
+    res.json(propuesta);
+  } catch (error) {
+    next(error);
+  }
+});
+
+export default router;

--- a/src/modules/tourism/tourism.router.ts
+++ b/src/modules/tourism/tourism.router.ts
@@ -1,0 +1,169 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import {
+  createBeneficio,
+  createPrograma,
+  createTestimonio,
+  deleteBeneficio,
+  deletePrograma,
+  deleteTestimonio,
+  listBeneficios,
+  listProgramas,
+  listTestimonios,
+  parseVisibleQuery,
+  updateBeneficio,
+  updatePrograma,
+  updateTestimonio
+} from './tourism.service';
+import { ApiError } from '../../core/errors';
+import { requireAuth } from '../users/auth.middleware';
+
+const router = Router();
+
+router.get('/programas', async (req, res, next) => {
+  try {
+    const visible = parseVisibleQuery(req.query.visible);
+    const programas = await listProgramas(visible);
+    res.json({ programas });
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.post('/programas', requireAuth, async (req, res, next) => {
+  try {
+    const programa = await createPrograma(req.body);
+    res.status(201).json({ programa });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      next(new ApiError(400, 'Datos inválidos', error.flatten()));
+      return;
+    }
+    next(error);
+  }
+});
+
+router.put('/programas/:id', requireAuth, async (req, res, next) => {
+  try {
+    const id = Number(req.params.id);
+    if (Number.isNaN(id)) throw new ApiError(400, 'ID inválido');
+    const programa = await updatePrograma(id, req.body);
+    res.json({ programa });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      next(new ApiError(400, 'Datos inválidos', error.flatten()));
+      return;
+    }
+    next(error);
+  }
+});
+
+router.delete('/programas/:id', requireAuth, async (req, res, next) => {
+  try {
+    const id = Number(req.params.id);
+    if (Number.isNaN(id)) throw new ApiError(400, 'ID inválido');
+    await deletePrograma(id);
+    res.status(204).send();
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.get('/beneficios', async (_req, res, next) => {
+  try {
+    const beneficios = await listBeneficios();
+    res.json({ beneficios });
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.post('/beneficios', requireAuth, async (req, res, next) => {
+  try {
+    const beneficio = await createBeneficio(req.body);
+    res.status(201).json({ beneficio });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      next(new ApiError(400, 'Datos inválidos', error.flatten()));
+      return;
+    }
+    next(error);
+  }
+});
+
+router.put('/beneficios/:id', requireAuth, async (req, res, next) => {
+  try {
+    const id = Number(req.params.id);
+    if (Number.isNaN(id)) throw new ApiError(400, 'ID inválido');
+    const beneficio = await updateBeneficio(id, req.body);
+    res.json({ beneficio });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      next(new ApiError(400, 'Datos inválidos', error.flatten()));
+      return;
+    }
+    next(error);
+  }
+});
+
+router.delete('/beneficios/:id', requireAuth, async (req, res, next) => {
+  try {
+    const id = Number(req.params.id);
+    if (Number.isNaN(id)) throw new ApiError(400, 'ID inválido');
+    await deleteBeneficio(id);
+    res.status(204).send();
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.get('/testimonios', async (req, res, next) => {
+  try {
+    const visible = parseVisibleQuery(req.query.visible);
+    const testimonios = await listTestimonios(visible);
+    res.json({ testimonios });
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.post('/testimonios', requireAuth, async (req, res, next) => {
+  try {
+    const testimonio = await createTestimonio(req.body);
+    res.status(201).json({ testimonio });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      next(new ApiError(400, 'Datos inválidos', error.flatten()));
+      return;
+    }
+    next(error);
+  }
+});
+
+router.put('/testimonios/:id', requireAuth, async (req, res, next) => {
+  try {
+    const id = Number(req.params.id);
+    if (Number.isNaN(id)) throw new ApiError(400, 'ID inválido');
+    const testimonio = await updateTestimonio(id, req.body);
+    res.json({ testimonio });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      next(new ApiError(400, 'Datos inválidos', error.flatten()));
+      return;
+    }
+    next(error);
+  }
+});
+
+router.delete('/testimonios/:id', requireAuth, async (req, res, next) => {
+  try {
+    const id = Number(req.params.id);
+    if (Number.isNaN(id)) throw new ApiError(400, 'ID inválido');
+    await deleteTestimonio(id);
+    res.status(204).send();
+  } catch (error) {
+    next(error);
+  }
+});
+
+export default router;

--- a/src/modules/tourism/tourism.schemas.ts
+++ b/src/modules/tourism/tourism.schemas.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod';
+
+export const programaSchema = z.object({
+  titulo: z.string().min(3).max(160).trim(),
+  descripcion: z.string().min(10).max(1000).trim(),
+  dias: z.number().int().positive(),
+  noches: z.number().int().nonnegative(),
+  allInclusive: z.boolean().optional(),
+  destino: z.string().min(2).max(120).trim(),
+  rating: z.number().min(0).max(5).optional(),
+  visible: z.boolean().default(true)
+});
+
+export const beneficioSchema = z.object({
+  titulo: z.string().min(3).max(160).trim(),
+  detalle: z.string().min(3).max(400).trim()
+});
+
+export const testimonioSchema = z.object({
+  autor: z.string().min(2).max(160).trim(),
+  contenido: z.string().min(10).max(800).trim(),
+  fuente: z.string().max(160).trim().optional(),
+  visible: z.boolean().default(true)
+});

--- a/src/modules/tourism/tourism.service.ts
+++ b/src/modules/tourism/tourism.service.ts
@@ -1,0 +1,94 @@
+import prisma from '../../core/prisma';
+import { ApiError } from '../../core/errors';
+import { beneficioSchema, programaSchema, testimonioSchema } from './tourism.schemas';
+
+export async function listProgramas(visible?: boolean) {
+  return prisma.programaTuristico.findMany({
+    where: visible === undefined ? {} : { visible },
+    orderBy: [{ visible: 'desc' }, { id: 'asc' }]
+  });
+}
+
+export async function createPrograma(data: unknown) {
+  const parsed = programaSchema.parse(data);
+  return prisma.programaTuristico.create({ data: parsed });
+}
+
+export async function updatePrograma(id: number, data: unknown) {
+  const parsed = programaSchema.partial().parse(data);
+  try {
+    return await prisma.programaTuristico.update({ where: { id }, data: parsed });
+  } catch (error) {
+    throw new ApiError(404, 'Programa no encontrado');
+  }
+}
+
+export async function deletePrograma(id: number) {
+  try {
+    await prisma.programaTuristico.delete({ where: { id } });
+  } catch (error) {
+    throw new ApiError(404, 'Programa no encontrado');
+  }
+}
+
+export async function listBeneficios() {
+  return prisma.beneficio.findMany({ orderBy: { id: 'asc' } });
+}
+
+export async function createBeneficio(data: unknown) {
+  const parsed = beneficioSchema.parse(data);
+  return prisma.beneficio.create({ data: parsed });
+}
+
+export async function updateBeneficio(id: number, data: unknown) {
+  const parsed = beneficioSchema.partial().parse(data);
+  try {
+    return await prisma.beneficio.update({ where: { id }, data: parsed });
+  } catch (error) {
+    throw new ApiError(404, 'Beneficio no encontrado');
+  }
+}
+
+export async function deleteBeneficio(id: number) {
+  try {
+    await prisma.beneficio.delete({ where: { id } });
+  } catch (error) {
+    throw new ApiError(404, 'Beneficio no encontrado');
+  }
+}
+
+export async function listTestimonios(visible?: boolean) {
+  return prisma.testimonio.findMany({
+    where: visible === undefined ? {} : { visible },
+    orderBy: [{ visible: 'desc' }, { id: 'asc' }]
+  });
+}
+
+export async function createTestimonio(data: unknown) {
+  const parsed = testimonioSchema.parse(data);
+  return prisma.testimonio.create({ data: parsed });
+}
+
+export async function updateTestimonio(id: number, data: unknown) {
+  const parsed = testimonioSchema.partial().parse(data);
+  try {
+    return await prisma.testimonio.update({ where: { id }, data: parsed });
+  } catch (error) {
+    throw new ApiError(404, 'Testimonio no encontrado');
+  }
+}
+
+export async function deleteTestimonio(id: number) {
+  try {
+    await prisma.testimonio.delete({ where: { id } });
+  } catch (error) {
+    throw new ApiError(404, 'Testimonio no encontrado');
+  }
+}
+
+export function parseVisibleQuery(value: unknown) {
+  if (value === undefined) return undefined;
+  if (value === 'true') return true;
+  if (value === 'false') return false;
+  throw new ApiError(400, 'Parámetro visible inválido');
+}

--- a/src/modules/users/auth.middleware.ts
+++ b/src/modules/users/auth.middleware.ts
@@ -1,0 +1,43 @@
+import { NextFunction, Request, Response } from 'express';
+import jwt from 'jsonwebtoken';
+import { AdminUserRole } from '@prisma/client';
+import env from '../../core/env';
+import { ApiError } from '../../core/errors';
+
+export interface AuthTokenPayload {
+  sub: number;
+  email: string;
+  role: string;
+  iat?: number;
+  exp?: number;
+}
+
+export function signToken(payload: Omit<AuthTokenPayload, 'iat' | 'exp'>) {
+  return jwt.sign(payload, env.JWT_SECRET, { expiresIn: env.JWT_EXPIRES_IN });
+}
+
+export function verifyToken(token: string): AuthTokenPayload {
+  try {
+    return jwt.verify(token, env.JWT_SECRET) as AuthTokenPayload;
+  } catch (error) {
+    throw new ApiError(401, 'Token inválido o expirado');
+  }
+}
+
+export function requireAuth(req: Request, _res: Response, next: NextFunction) {
+  const authHeader = req.headers.authorization;
+  if (!authHeader?.startsWith('Bearer ')) {
+    throw new ApiError(401, 'Autenticación requerida');
+  }
+
+  const token = authHeader.substring('Bearer '.length);
+  const payload = verifyToken(token);
+
+  req.user = {
+    id: payload.sub,
+    email: payload.email,
+    role: payload.role as AdminUserRole
+  };
+
+  next();
+}

--- a/src/modules/users/auth.router.ts
+++ b/src/modules/users/auth.router.ts
@@ -1,0 +1,40 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import { ApiError } from '../../core/errors';
+import { login, getMe } from './auth.service';
+import { requireAuth } from './auth.middleware';
+
+const router = Router();
+
+const loginSchema = z.object({
+  email: z.string().email(),
+  password: z.string().min(6)
+});
+
+router.post('/login', async (req, res, next) => {
+  try {
+    const { email, password } = loginSchema.parse(req.body);
+    const result = await login(email, password);
+    res.json(result);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      next(new ApiError(400, 'Datos inválidos', error.flatten()));
+      return;
+    }
+    next(error);
+  }
+});
+
+router.get('/me', requireAuth, async (req, res, next) => {
+  try {
+    if (!req.user) {
+      throw new ApiError(401, 'Autenticación requerida');
+    }
+    const user = await getMe(req.user.id);
+    res.json({ user });
+  } catch (error) {
+    next(error);
+  }
+});
+
+export default router;

--- a/src/modules/users/auth.service.ts
+++ b/src/modules/users/auth.service.ts
@@ -1,0 +1,39 @@
+import bcrypt from 'bcryptjs';
+import prisma from '../../core/prisma';
+import { ApiError } from '../../core/errors';
+import { signToken } from './auth.middleware';
+
+export async function login(email: string, password: string) {
+  const user = await prisma.adminUser.findUnique({ where: { email } });
+  if (!user) {
+    throw new ApiError(401, 'Credenciales inválidas');
+  }
+
+  const isMatch = await bcrypt.compare(password, user.hash);
+  if (!isMatch) {
+    throw new ApiError(401, 'Credenciales inválidas');
+  }
+
+  const token = signToken({ sub: user.id, email: user.email, role: user.role });
+  return {
+    token,
+    user: {
+      id: user.id,
+      email: user.email,
+      role: user.role
+    }
+  };
+}
+
+export async function getMe(userId: number) {
+  const user = await prisma.adminUser.findUnique({
+    where: { id: userId },
+    select: { id: true, email: true, role: true }
+  });
+
+  if (!user) {
+    throw new ApiError(404, 'Usuario no encontrado');
+  }
+
+  return user;
+}

--- a/src/routes/health.ts
+++ b/src/routes/health.ts
@@ -1,0 +1,15 @@
+import { Router } from 'express';
+import prisma from '../core/prisma';
+
+const router = Router();
+
+router.get('/healthz', async (_req, res) => {
+  try {
+    await prisma.$queryRaw`SELECT 1`;
+    res.json({ status: 'ok' });
+  } catch (error) {
+    res.status(500).json({ status: 'error', details: (error as Error).message });
+  }
+});
+
+export default router;

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,0 +1,18 @@
+import { Router } from 'express';
+import formsRouter from '../modules/forms/forms.router';
+import tourismRouter from '../modules/tourism/tourism.router';
+import cleBrokerRouter from '../modules/cle_broker/cleBroker.router';
+import authRouter from '../modules/users/auth.router';
+import publicRouter from '../modules/public/public.router';
+import healthRouter from './health';
+
+const router = Router();
+
+router.use('/forms', formsRouter);
+router.use('/tourism', tourismRouter);
+router.use('/cle-broker', cleBrokerRouter);
+router.use('/auth', authRouter);
+router.use('/public', publicRouter);
+router.use('/', healthRouter);
+
+export default router;

--- a/src/scripts/seed.ts
+++ b/src/scripts/seed.ts
@@ -1,0 +1,190 @@
+import bcrypt from 'bcryptjs';
+import prisma from '../core/prisma';
+import env from '../core/env';
+import logger from '../core/logger';
+
+async function seedAdmin() {
+  const hash = await bcrypt.hash(env.ADMIN_PASSWORD, 10);
+  await prisma.adminUser.upsert({
+    where: { email: env.ADMIN_EMAIL },
+    update: { hash },
+    create: { email: env.ADMIN_EMAIL, hash, role: 'ADMIN' }
+  });
+  logger.info('Usuario admin preparado');
+}
+
+async function seedBeneficios() {
+  const count = await prisma.beneficio.count();
+  if (count === 0) {
+    await prisma.beneficio.createMany({
+      data: [
+        { titulo: 'Acceso a paquetes exclusivos de socios de membresía', detalle: 'Reservas preferenciales con aliados estratégicos.' },
+        { titulo: 'Precios especiales', detalle: 'Tarifas negociadas para optimizar tu presupuesto de viaje.' },
+        { titulo: 'Flexibilidad en fechas y destinos', detalle: 'Adaptamos la experiencia a tus necesidades.' },
+        { titulo: 'Asesoría personalizada', detalle: 'Acompañamiento experto en cada etapa del viaje.' },
+        { titulo: 'Respaldo oficial', detalle: 'Soporte con garantía KayrosGo / Cle_Broker.' }
+      ]
+    });
+    logger.info('Beneficios base insertados');
+  }
+}
+
+async function seedProgramas() {
+  const count = await prisma.programaTuristico.count();
+  if (count === 0) {
+    await prisma.programaTuristico.createMany({
+      data: [
+        {
+          titulo: 'Cancún All Inclusive – 4 noches',
+          descripcion: 'Disfruta de Cancún en hotel 5 estrellas con plan todo incluido y traslados.',
+          dias: 5,
+          noches: 4,
+          allInclusive: true,
+          destino: 'Cancún, México',
+          rating: 4.8,
+          visible: true
+        },
+        {
+          titulo: 'Europa Express – 7 días',
+          descripcion: 'Recorre España, Francia e Italia en un itinerario dinámico y lleno de cultura.',
+          dias: 7,
+          noches: 6,
+          allInclusive: false,
+          destino: 'Europa',
+          rating: 4.6,
+          visible: true
+        },
+        {
+          titulo: 'Caribe Familiar – 5 noches',
+          descripcion: 'Paquete pensado para familias con actividades y resorts todo incluido.',
+          dias: 6,
+          noches: 5,
+          allInclusive: true,
+          destino: 'Caribe',
+          rating: 4.7,
+          visible: true
+        }
+      ]
+    });
+    logger.info('Programas turísticos base insertados');
+  }
+}
+
+async function seedTestimonios() {
+  const count = await prisma.testimonio.count();
+  if (count === 0) {
+    await prisma.testimonio.createMany({
+      data: [
+        {
+          autor: 'Mariana G.',
+          contenido: 'KayrosGo nos ayudó a coordinar un viaje inolvidable al Caribe con toda mi familia. Excelente atención.',
+          fuente: 'Google Reviews',
+          visible: true
+        },
+        {
+          autor: 'Luis P.',
+          contenido: 'Gracias a Cle_Broker obtuvimos tarifas corporativas muy competitivas para nuestro equipo.',
+          visible: true
+        },
+        {
+          autor: 'Andrea R.',
+          contenido: 'La asesoría personalizada hizo la diferencia, encontramos el programa ideal para celebrar nuestro aniversario.',
+          visible: true
+        }
+      ]
+    });
+    logger.info('Testimonios base insertados');
+  }
+}
+
+async function seedServicios() {
+  const count = await prisma.servicioCleBroker.count();
+  if (count === 0) {
+    await prisma.servicioCleBroker.createMany({
+      data: [
+        {
+          titulo: 'Hoteles a precios cómodos',
+          descripcionCorta: 'Negociamos tarifas preferenciales en hoteles reconocidos.',
+          descripcionLarga: 'Tarifas dinámicas con disponibilidad confirmada y upgrades sujetos a disponibilidad.',
+          orden: 1,
+          visible: true
+        },
+        {
+          titulo: 'Alquiler de autos',
+          descripcionCorta: 'Cobertura internacional con aliados de confianza.',
+          descripcionLarga: 'Reservas inmediatas, seguros incluidos y opciones flexibles por día o semana.',
+          orden: 2,
+          visible: true
+        },
+        {
+          titulo: 'Cruceros',
+          descripcionCorta: 'Itinerarios por el Caribe, Mediterráneo y Alaska.',
+          descripcionLarga: 'Experiencias premium con planes familiares y de lujo.',
+          orden: 3,
+          visible: true
+        },
+        {
+          titulo: 'Planes 5d/4n',
+          descripcionCorta: 'Programas diseñados para escapadas completas.',
+          descripcionLarga: 'Incluye vuelos, hotel y asistencia personalizada en destino.',
+          orden: 4,
+          visible: true
+        },
+        {
+          titulo: 'Hoteles con alimentación',
+          descripcionCorta: 'Desayuno, media pensión o todo incluido según tus preferencias.',
+          orden: 5,
+          visible: true
+        }
+      ]
+    });
+    logger.info('Servicios Cle_Broker base insertados');
+  }
+}
+
+async function seedConfig() {
+  await prisma.config.upsert({
+    where: { clave: 'membresiaCodigo' },
+    update: { valorJSON: JSON.stringify('R9025') },
+    create: { clave: 'membresiaCodigo', valorJSON: JSON.stringify('R9025') }
+  });
+
+  await prisma.config.upsert({
+    where: { clave: 'propuestaProceso' },
+    update: {
+      valorJSON: JSON.stringify([
+        { titulo: 'Paso 1', descripcion: 'Elige tu programa favorito' },
+        { titulo: 'Paso 2', descripcion: 'Recibe una cotización oficial con respaldo' },
+        { titulo: 'Paso 3', descripcion: 'Viaja con tranquilidad y soporte permanente' }
+      ])
+    },
+    create: {
+      clave: 'propuestaProceso',
+      valorJSON: JSON.stringify([
+        { titulo: 'Paso 1', descripcion: 'Elige tu programa favorito' },
+        { titulo: 'Paso 2', descripcion: 'Recibe una cotización oficial con respaldo' },
+        { titulo: 'Paso 3', descripcion: 'Viaja con tranquilidad y soporte permanente' }
+      ])
+    }
+  });
+
+  logger.info('Configuraciones base actualizadas');
+}
+
+async function main() {
+  await seedAdmin();
+  await seedBeneficios();
+  await seedProgramas();
+  await seedTestimonios();
+  await seedServicios();
+  await seedConfig();
+}
+
+main()
+  .catch((error) => {
+    logger.error({ error }, 'Error durante la semilla');
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,39 @@
+import express from 'express';
+import helmet from 'helmet';
+import cors from 'cors';
+import env from './core/env';
+import logger from './core/logger';
+import { createRateLimiter } from './core/rateLimit';
+import routes from './routes';
+import { errorHandler, notFoundHandler } from './core/errors';
+
+const app = express();
+app.set('trust proxy', true);
+
+app.use(helmet());
+app.use(
+  cors({
+    origin: env.CORS_ORIGIN ? env.CORS_ORIGIN.split(',') : env.BASE_URL,
+    credentials: true
+  })
+);
+app.use(express.json({ limit: '1mb' }));
+app.use(createRateLimiter());
+
+app.get('/', (_req, res) => {
+  res.json({ name: 'KayrosGo / Cle_Broker API', version: '1.0.0' });
+});
+
+app.use('/api', routes);
+
+app.use(notFoundHandler);
+app.use(errorHandler);
+
+if (env.NODE_ENV !== 'test') {
+  const port = Number(env.PORT ?? 3000);
+  app.listen(port, () => {
+    logger.info(`Servidor escuchando en puerto ${port}`);
+  });
+}
+
+export default app;

--- a/src/tests/auth.test.ts
+++ b/src/tests/auth.test.ts
@@ -1,0 +1,43 @@
+import bcrypt from 'bcryptjs';
+import request from 'supertest';
+
+jest.mock('../core/prisma', () => require('./utils/prismaMock').default);
+
+import app from '../server';
+import prismaMock from './utils/prismaMock';
+
+describe('Auth routes', () => {
+  it('should authenticate admin user and return a token', async () => {
+    const password = 'Admin123!';
+    const hash = await bcrypt.hash(password, 10);
+
+    prismaMock.adminUser.findUnique.mockResolvedValue({
+      id: 1,
+      email: 'admin@example.com',
+      hash,
+      role: 'ADMIN',
+      createdAt: new Date(),
+      updatedAt: new Date()
+    });
+
+    const response = await request(app).post('/api/auth/login').send({
+      email: 'admin@example.com',
+      password
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.token).toBeDefined();
+    expect(response.body.user.email).toBe('admin@example.com');
+  });
+
+  it('should reject invalid credentials', async () => {
+    prismaMock.adminUser.findUnique.mockResolvedValue(null as any);
+
+    const response = await request(app).post('/api/auth/login').send({
+      email: 'admin@example.com',
+      password: 'wrongpassword'
+    });
+
+    expect(response.status).toBe(401);
+  });
+});

--- a/src/tests/forms.test.ts
+++ b/src/tests/forms.test.ts
@@ -1,0 +1,53 @@
+import request from 'supertest';
+
+jest.mock('../core/prisma', () => require('./utils/prismaMock').default);
+const sendMailMock = jest.fn();
+jest.mock('../core/mailer', () => ({
+  sendMail: sendMailMock
+}));
+
+import app from '../server';
+import prismaMock from './utils/prismaMock';
+
+const contactoPayload = {
+  nombre: 'Juan Pérez',
+  email: 'juan@example.com',
+  whatsapp: '+573001234567',
+  destinoInteres: 'Cancún'
+};
+
+describe('Forms routes', () => {
+  beforeEach(() => {
+    sendMailMock.mockReset();
+  });
+
+  it('should create a lead from contacto form and send confirmation email', async () => {
+    prismaMock.lead.create.mockResolvedValue({ id: 1, ...contactoPayload, origenFormulario: 'contacto' });
+
+    const response = await request(app).post('/api/forms/contacto').send(contactoPayload);
+
+    expect(response.status).toBe(201);
+    expect(response.body.leadId).toBe(1);
+    expect(sendMailMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should create a cotizacion and notify admin and user', async () => {
+    prismaMock.lead.create.mockResolvedValue({ id: 10, ...contactoPayload, origenFormulario: 'cotizacion' });
+    prismaMock.cotizacion.create.mockResolvedValue({
+      id: 5,
+      leadId: 10,
+      mensaje: 'Me interesa viajar en junio',
+      estado: 'pendiente',
+      lead: { id: 10, ...contactoPayload, origenFormulario: 'cotizacion' },
+      programa: { id: 3, titulo: 'Cancún All Inclusive – 4 noches' }
+    });
+
+    const response = await request(app)
+      .post('/api/forms/cotizacion')
+      .send({ ...contactoPayload, programaId: 3, mensaje: 'Me interesa viajar en junio' });
+
+    expect(response.status).toBe(201);
+    expect(response.body.cotizacionId).toBe(5);
+    expect(sendMailMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/tests/setup.ts
+++ b/src/tests/setup.ts
@@ -1,0 +1,21 @@
+import prismaMock from './utils/prismaMock';
+
+process.env.NODE_ENV = 'test';
+process.env.DATABASE_URL = process.env.DATABASE_URL ?? 'postgresql://postgres:postgres@localhost:5432/cle_broker';
+process.env.JWT_SECRET = process.env.JWT_SECRET ?? 'testsecret';
+process.env.JWT_EXPIRES_IN = '15m';
+process.env.ADMIN_EMAIL = process.env.ADMIN_EMAIL ?? 'admin@example.com';
+process.env.ADMIN_PASSWORD = process.env.ADMIN_PASSWORD ?? 'Admin123!';
+process.env.SMTP_HOST = process.env.SMTP_HOST ?? 'smtp.example.com';
+process.env.SMTP_PORT = '587';
+process.env.SMTP_USER = process.env.SMTP_USER ?? 'user';
+process.env.SMTP_PASS = process.env.SMTP_PASS ?? 'pass';
+process.env.BASE_URL = process.env.BASE_URL ?? 'http://localhost:3000';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  prismaMock.lead.create.mockReset();
+  prismaMock.cotizacion.create.mockReset();
+  prismaMock.programaTuristico.findMany.mockReset();
+  prismaMock.adminUser.findUnique.mockReset();
+});

--- a/src/tests/tourism.test.ts
+++ b/src/tests/tourism.test.ts
@@ -1,0 +1,24 @@
+import request from 'supertest';
+
+jest.mock('../core/prisma', () => require('./utils/prismaMock').default);
+
+import app from '../server';
+import prismaMock from './utils/prismaMock';
+
+describe('Tourism routes', () => {
+  it('should list visible programs', async () => {
+    prismaMock.programaTuristico.findMany.mockResolvedValue([
+      { id: 1, titulo: 'Cancún All Inclusive – 4 noches', visible: true },
+      { id: 2, titulo: 'Europa Express – 7 días', visible: true }
+    ]);
+
+    const response = await request(app).get('/api/tourism/programas').query({ visible: 'true' });
+
+    expect(response.status).toBe(200);
+    expect(response.body.programas).toHaveLength(2);
+    expect(prismaMock.programaTuristico.findMany).toHaveBeenCalledWith({
+      where: { visible: true },
+      orderBy: [{ visible: 'desc' }, { id: 'asc' }]
+    });
+  });
+});

--- a/src/tests/utils/prismaMock.ts
+++ b/src/tests/utils/prismaMock.ts
@@ -1,0 +1,46 @@
+const prismaMock = {
+  lead: {
+    create: jest.fn()
+  },
+  cotizacion: {
+    create: jest.fn()
+  },
+  programaTuristico: {
+    findMany: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn()
+  },
+  beneficio: {
+    findMany: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn()
+  },
+  testimonio: {
+    findMany: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn()
+  },
+  servicioCleBroker: {
+    findMany: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn()
+  },
+  adminUser: {
+    findUnique: jest.fn(),
+    upsert: jest.fn()
+  },
+  config: {
+    findMany: jest.fn(),
+    upsert: jest.fn()
+  },
+  $queryRaw: jest.fn().mockResolvedValue([{ '?column?': 1 }]),
+  $disconnect: jest.fn()
+} as const;
+
+export type PrismaMock = typeof prismaMock;
+
+export default prismaMock;

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -1,0 +1,17 @@
+import { AdminUserRole } from '@prisma/client';
+
+declare global {
+  namespace Express {
+    interface User {
+      id: number;
+      email: string;
+      role: AdminUserRole;
+    }
+
+    interface Request {
+      user?: User;
+    }
+  }
+}
+
+export {};

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false
+  },
+  "exclude": ["src/tests", "src/**/*.test.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "types": ["node", "jest"]
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- add a modular Node.js 20 + Express API with routes for forms, tourism, Cle_Broker services, public proposal bundle and admin auth
- configure Prisma schema, SQL migration, seed script, mailer, rate limiting, Docker tooling and environment validation
- document setup/integration flows and add Jest + Supertest coverage for auth, form submission and tourism listings

## Testing
- not run (npm install blocked by registry access restrictions in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e9a28cea34832abc5d30aad40883c8