### PR TITLE
Add Flask backend and wire up site forms

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,3 +75,71 @@ Puedes adaptar fácilmente el proyecto según tus necesidades:
 * **Estilos:** modifica los colores, tipografías y tamaños en `css/estilos.css`.
 * **Scripts:** agrega o ajusta funciones en `js/main.js` para ampliar interactividad.
 * **Logos e íconos:** reemplaza los archivos en `img/` o usa SVG personalizados.
+
+## Backend: API y base de datos
+
+El proyecto ahora incluye un backend opcional para almacenar la información
+recogida desde los formularios (contacto, newsletter y cotización de
+talleres) en una base de datos SQLite.
+
+### Requisitos previos
+
+* **Python 3.10 o superior.** Verifica tu versión con `python --version`.
+* (Opcional pero recomendado) **Entorno virtual** para aislar dependencias.
+
+### Instalación paso a paso
+
+1. **Crear y activar un entorno virtual**
+
+   ```bash
+   python -m venv .venv
+   # Windows
+   .\.venv\Scripts\activate
+   # macOS / Linux
+   source .venv/bin/activate
+   ```
+
+2. **Instalar dependencias del backend**
+
+   ```bash
+   pip install -r backend/requirements.txt
+   ```
+
+3. **Iniciar la API**
+
+   ```bash
+   python backend/app.py
+   ```
+
+   Por defecto quedará escuchando en `http://localhost:8000` y creará el
+   archivo de base de datos `backend/instance/cle_broker.sqlite` la primera
+   vez que se ejecute.
+
+4. **Ejecutar el sitio estático (opcional)**
+
+   En otra terminal puedes usar los scripts existentes para ver el sitio
+   mientras el backend está activo:
+
+   ```bash
+   ./run.sh
+   # o en Windows
+   run.bat
+   ```
+
+### Endpoints disponibles
+
+| Método | Ruta              | Descripción                                    |
+| ------ | ----------------- | ---------------------------------------------- |
+| GET    | `/api/health`     | Verificación rápida del estado del backend.   |
+| POST   | `/api/contact`    | Registra un mensaje del formulario de contacto.|
+| POST   | `/api/newsletter` | Guarda solicitudes del formulario de inicio.  |
+| POST   | `/api/workshops`  | Registra solicitudes de cotización de talleres.|
+
+Cada petición devuelve un mensaje de confirmación y el identificador del
+registro creado dentro de la base de datos.
+
+### Configuración del frontend
+
+El archivo `js/app-config.js` define la variable `apiBaseUrl`. Si despliegas
+el backend en otra URL o puerto, actualiza este valor para que los
+formularios sigan apuntando correctamente a la API.

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,0 +1,207 @@
+"""Aplicación backend sencilla para CLE_BROKER.
+
+Este módulo expone una API REST mínima basada en Flask que permite
+almacenar la información enviada desde los formularios del sitio web en
+una base de datos SQLite.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Iterable, List
+
+from flask import Flask, jsonify, request
+from flask_cors import CORS
+from flask_sqlalchemy import SQLAlchemy
+
+
+db = SQLAlchemy()
+
+
+class TimestampMixin:
+    """Mixin para agregar campos de auditoría básicos."""
+
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+
+class ContactMessage(db.Model, TimestampMixin):
+    __tablename__ = "contact_messages"
+
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(120), nullable=False)
+    email = db.Column(db.String(120), nullable=False)
+    phone = db.Column(db.String(50))
+    subject = db.Column(db.String(255))
+    message = db.Column(db.Text, nullable=False)
+    preferred_channels = db.Column(db.String(255))
+
+
+class NewsletterSubscription(db.Model, TimestampMixin):
+    __tablename__ = "newsletter_subscriptions"
+
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(120), nullable=False)
+    email = db.Column(db.String(120), nullable=False)
+    requirements = db.Column(db.Text)
+
+
+class WorkshopQuoteRequest(db.Model, TimestampMixin):
+    __tablename__ = "workshop_quote_requests"
+
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(120), nullable=False)
+    phone = db.Column(db.String(50), nullable=False)
+    topic = db.Column(db.String(120), nullable=False)
+
+
+@dataclass
+class ApiResponse:
+    message: str
+    data: Dict[str, Any]
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+def _ensure_instance_dir(app: Flask) -> Path:
+    instance_path = Path(os.environ.get("CLE_BROKER_INSTANCE", app.instance_path))
+    instance_path.mkdir(parents=True, exist_ok=True)
+    return instance_path
+
+
+def create_app() -> Flask:
+    """Crea y configura la aplicación Flask."""
+
+    app = Flask(__name__)
+    CORS(app)
+
+    instance_path = _ensure_instance_dir(app)
+    database_url = os.environ.get(
+        "CLE_BROKER_DATABASE_URL", f"sqlite:///{instance_path / 'cle_broker.sqlite'}"
+    )
+
+    app.config["SQLALCHEMY_DATABASE_URI"] = database_url
+    app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
+
+    db.init_app(app)
+
+    with app.app_context():
+        db.create_all()
+
+    register_routes(app)
+
+    return app
+
+
+def parse_request_json(required_fields: Iterable[str]) -> Dict[str, Any]:
+    """Obtiene el JSON de la petición y valida los campos obligatorios."""
+
+    if not request.is_json:
+        return {}
+
+    payload: Dict[str, Any] = request.get_json(force=True) or {}
+
+    missing = [field for field in required_fields if not payload.get(field)]
+    if missing:
+        raise ValueError(f"Faltan campos obligatorios: {', '.join(missing)}")
+
+    return payload
+
+
+def normalise_multi_value(raw_value: Any) -> List[str]:
+    """Convierte un valor recibido desde el formulario en una lista de strings."""
+
+    if raw_value is None:
+        return []
+    if isinstance(raw_value, str):
+        return [part.strip() for part in raw_value.split(",") if part.strip()]
+    if isinstance(raw_value, (list, tuple)):
+        return [str(item) for item in raw_value if str(item).strip()]
+    return [str(raw_value)]
+
+
+def register_routes(app: Flask) -> None:
+    """Registra las rutas de la API."""
+
+    @app.get("/api/health")
+    def health_check() -> Any:
+        return jsonify(status="ok"), 200
+
+    @app.post("/api/contact")
+    def create_contact_message() -> Any:
+        try:
+            payload = parse_request_json(["name", "email", "message"])
+        except ValueError as exc:
+            return jsonify(error=str(exc)), 400
+
+        preferred_channels = ",".join(normalise_multi_value(payload.get("preferred")))
+
+        message = ContactMessage(
+            name=payload.get("name"),
+            email=payload.get("email"),
+            phone=payload.get("phone"),
+            subject=payload.get("subject"),
+            message=payload.get("message"),
+            preferred_channels=preferred_channels,
+        )
+        db.session.add(message)
+        db.session.commit()
+
+        response = ApiResponse(
+            message="Solicitud registrada correctamente.",
+            data={"id": message.id},
+        )
+        return jsonify(response.to_dict()), 201
+
+    @app.post("/api/newsletter")
+    def create_newsletter_subscription() -> Any:
+        try:
+            payload = parse_request_json(["name", "email"])
+        except ValueError as exc:
+            return jsonify(error=str(exc)), 400
+
+        subscription = NewsletterSubscription(
+            name=payload.get("name"),
+            email=payload.get("email"),
+            requirements=payload.get("requirements"),
+        )
+        db.session.add(subscription)
+        db.session.commit()
+
+        response = ApiResponse(
+            message="Suscripción registrada. ¡Gracias por escribirnos!",
+            data={"id": subscription.id},
+        )
+        return jsonify(response.to_dict()), 201
+
+    @app.post("/api/workshops")
+    def create_workshop_quote() -> Any:
+        try:
+            payload = parse_request_json(["name", "phone", "subject"])
+        except ValueError as exc:
+            return jsonify(error=str(exc)), 400
+
+        quote = WorkshopQuoteRequest(
+            name=payload.get("name"),
+            phone=payload.get("phone"),
+            topic=payload.get("subject"),
+        )
+        db.session.add(quote)
+        db.session.commit()
+
+        response = ApiResponse(
+            message="Solicitud de cotización recibida.",
+            data={"id": quote.id},
+        )
+        return jsonify(response.to_dict()), 201
+
+
+app = create_app()
+
+
+if __name__ == "__main__":  # pragma: no cover - ejecución directa
+    port = int(os.environ.get("PORT", 8000))
+    app.run(host="0.0.0.0", port=port, debug=True)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,3 @@
+Flask==3.0.3
+Flask-Cors==4.0.0
+Flask-SQLAlchemy==3.1.1

--- a/contacto.html
+++ b/contacto.html
@@ -185,9 +185,11 @@
                 mejores
                 opciones.</p>
             </div>
-            <form class="form-a">
-              <div id="sendmessage">¡Tu mensaje ha sido enviado! Te contactaremos pronto.</div>
-              <div id="errormessage"></div>
+            <form class="form-a" data-endpoint="/api/contact"
+              data-success-message="¡Tu mensaje ha sido enviado! Te contactaremos pronto." data-error-message="No
+              pudimos enviar tu mensaje. Inténtalo de nuevo más tarde.">
+              <div class="form-message form-message-success" role="status" hidden></div>
+              <div class="form-message form-message-error" role="alert" hidden></div>
               <div class="row g-3">
                 <div class="col-md-6">
                   <div class="form-group">
@@ -228,9 +230,9 @@
                   <div class="form-group">
                     <label class="form-label">¿Cómo prefieres que te contactemos?</label>
                     <div class="contact-preferences">
-                      <label><input type="checkbox" name="preferred[]" value="telefono"> Teléfono</label>
-                      <label><input type="checkbox" name="preferred[]" value="whatsapp"> WhatsApp</label>
-                      <label><input type="checkbox" name="preferred[]" value="email"> Email</label>
+                      <label><input type="checkbox" name="preferred" value="telefono"> Teléfono</label>
+                      <label><input type="checkbox" name="preferred" value="whatsapp"> WhatsApp</label>
+                      <label><input type="checkbox" name="preferred" value="email"> Email</label>
                     </div>
                   </div>
                 </div>
@@ -354,7 +356,8 @@
   <script src="lib/easing/easing.min.js"></script>
   <script src="lib/owlcarousel/owl.carousel.min.js"></script>
   <script src="lib/scrollreveal/scrollreveal.min.js"></script>
-  <script src="contactform/contactform.js"></script>
+  <script src="js/app-config.js"></script>
+  <script src="js/contactform.js"></script>
   <script src="js/main.js"></script>
   <script>window.CHATBOT_CONFIG = window.CHATBOT_CONFIG || {};</script>
   <script src="js/chatbot.widget.js"></script>

--- a/css/style.css
+++ b/css/style.css
@@ -2680,3 +2680,23 @@ footer .credits {
 .section-footer .w-footer-a li {
   list-style: none;
 }
+
+.form-message {
+  margin-bottom: 1rem;
+  padding: 0.75rem 1rem;
+  border-radius: 0.5rem;
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.form-message-success {
+  background: #e8f8f0;
+  border: 1px solid #4caf50;
+  color: #256029;
+}
+
+.form-message-error {
+  background: #fdecea;
+  border: 1px solid #f44336;
+  color: #a01e1e;
+}

--- a/faq.html
+++ b/faq.html
@@ -275,7 +275,8 @@
   <script src="lib/easing/easing.min.js"></script>
   <script src="lib/owlcarousel/owl.carousel.min.js"></script>
   <script src="lib/scrollreveal/scrollreveal.min.js"></script>
-  <script src="contactform/contactform.js"></script>
+  <script src="js/app-config.js"></script>
+  <script src="js/contactform.js"></script>
   <script src="js/main.js"></script>
   <script src="js/faq.page.js"></script>
   <script src="js/chatbot.widget.js"></script>

--- a/index.html
+++ b/index.html
@@ -454,16 +454,23 @@
           <div class="col-md-8 text-center">
             <h3>¿Buscas una propiedad específica?</h3>
             <p>Déjanos tus datos y te contactaremos con las mejores opciones disponibles</p>
-            <form class="form-a">
+            <form class="form-a" data-endpoint="/api/newsletter"
+              data-success-message="¡Gracias! Un asesor te contactará muy pronto."
+              data-error-message="No pudimos registrar tu solicitud. Intenta nuevamente en unos minutos.">
+              <div class="form-message form-message-success" role="status" hidden></div>
+              <div class="form-message form-message-error" role="alert" hidden></div>
               <div class="row">
                 <div class="col-md-6 mb-2">
-                  <input type="text" class="form-control form-control-lg" placeholder="Tu nombre" required>
+                  <input type="text" name="name" class="form-control form-control-lg"
+                    placeholder="Tu nombre" required>
                 </div>
                 <div class="col-md-6 mb-2">
-                  <input type="email" class="form-control form-control-lg" placeholder="Tu email" required>
+                  <input type="email" name="email" class="form-control form-control-lg"
+                    placeholder="Tu email" required>
                 </div>
                 <div class="col-md-12 mb-2">
-                  <textarea class="form-control" placeholder="¿Qué tipo de propiedad buscas?" rows="4"></textarea>
+                  <textarea name="requirements" class="form-control"
+                    placeholder="¿Qué tipo de propiedad buscas?" rows="4"></textarea>
                 </div>
                 <div class="col-md-12">
                   <button type="submit" class="improved-btn improved-btn-primary">Enviar solicitud</button>
@@ -537,8 +544,9 @@
   <script src="lib/easing/easing.min.js"></script>
   <script src="lib/owlcarousel/owl.carousel.min.js"></script>
   <script src="lib/scrollreveal/scrollreveal.min.js"></script>
-  <!-- Contact Form JavaScript File -->
-  <script src="contactform/contactform.js"></script>
+  <!-- Configuración y manejo de formularios -->
+  <script src="js/app-config.js"></script>
+  <script src="js/contactform.js"></script>
 
   <!-- Template Main Javascript File -->
   <script src="js/main.js"></script>

--- a/js/app-config.js
+++ b/js/app-config.js
@@ -1,0 +1,6 @@
+window.APP_CONFIG = Object.assign(
+  {
+    apiBaseUrl: 'http://localhost:8000',
+  },
+  window.APP_CONFIG || {}
+);

--- a/servicios.html
+++ b/servicios.html
@@ -369,7 +369,8 @@
   <script src="lib/easing/easing.min.js"></script>
   <script src="lib/owlcarousel/owl.carousel.min.js"></script>
   <script src="lib/scrollreveal/scrollreveal.min.js"></script>
-  <script src="contactform/contactform.js"></script>
+  <script src="js/app-config.js"></script>
+  <script src="js/contactform.js"></script>
   <script src="js/main.js"></script>
   <script src="js/servicios.page.js"></script>
   <script>window.CHATBOT_CONFIG = window.CHATBOT_CONFIG || {};</script>

--- a/sobre-nosotros.html
+++ b/sobre-nosotros.html
@@ -277,7 +277,8 @@
   <script src="lib/easing/easing.min.js"></script>
   <script src="lib/owlcarousel/owl.carousel.min.js"></script>
   <script src="lib/scrollreveal/scrollreveal.min.js"></script>
-  <script src="contactform/contactform.js"></script>
+  <script src="js/app-config.js"></script>
+  <script src="js/contactform.js"></script>
   <script src="js/main.js"></script>
   <script>window.CHATBOT_CONFIG = window.CHATBOT_CONFIG || {};</script>
   <script src="js/chatbot.widget.js"></script>

--- a/talleres.html
+++ b/talleres.html
@@ -264,9 +264,11 @@
             </ul>
           </div>
           <div class="col-lg-6">
-            <form class="form-a contactForm workshops-quote-form" method="post" role="form" action="" data-stub="true">
-              <div id="sendmessage">¡Tu mensaje ha sido enviado! Te contactaremos pronto.</div>
-              <div id="errormessage"></div>
+            <form class="form-a workshops-quote-form" method="post" role="form" data-endpoint="/api/workshops"
+              data-success-message="¡Gracias! Te escribiremos con la cotización en menos de 24 horas."
+              data-error-message="No pudimos registrar tu solicitud. Vuelve a intentarlo o escríbenos por WhatsApp.">
+              <div class="form-message form-message-success" role="status" hidden></div>
+              <div class="form-message form-message-error" role="alert" hidden></div>
               <div class="row g-3">
                 <div class="col-12">
                   <div class="form-group">
@@ -419,6 +421,7 @@
   <script src="lib/easing/easing.min.js"></script>
   <script src="lib/owlcarousel/owl.carousel.min.js"></script>
   <script src="lib/scrollreveal/scrollreveal.min.js"></script>
+  <script src="js/app-config.js"></script>
   <script src="js/contactform.js"></script>
   <script src="js/main.js"></script>
   <script>window.CHATBOT_CONFIG = window.CHATBOT_CONFIG || {};</script>


### PR DESCRIPTION
## Summary
- add a Flask backend with SQLite persistence for contact, newsletter, and workshop submissions
- update the site forms and scripts to post to the new API and display inline success/error feedback
- document backend setup and configuration steps in the README

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68e9c1c2428c832a94251a90d039d938