### PR TITLE
Add KayrosGo tourism experiences to services page

### DIFF
--- a/css/servicios.page.css
+++ b/css/servicios.page.css
@@ -198,6 +198,383 @@
   box-shadow: var(--shadow-hover);
 }
 
+.btn-tourism-link {
+  border-color: rgba(255, 255, 255, 0.7);
+  color: #ffffff;
+  background: rgba(255, 255, 255, 0.08);
+  backdrop-filter: blur(4px);
+}
+
+.btn-tourism-link:hover {
+  color: #ffffff;
+  background: rgba(255, 255, 255, 0.18);
+}
+
+.tourism-intro {
+  position: relative;
+  padding-top: 6rem;
+  padding-bottom: 6rem;
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.05) 0%, rgba(37, 99, 235, 0.08) 100%);
+}
+
+.tourism-intro__content {
+  padding: 3rem;
+  border-radius: 28px;
+  background: rgba(255, 255, 255, 0.95);
+  border: 1px solid rgba(37, 99, 235, 0.14);
+  box-shadow: 0 35px 65px rgba(15, 23, 42, 0.12);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.tourism-intro__content h2 {
+  font-size: 2.35rem;
+}
+
+.tourism-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.5rem 1.2rem;
+  border-radius: 999px;
+  background: rgba(37, 99, 235, 0.1);
+  color: var(--color-primary);
+  font-weight: 600;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+}
+
+.tourism-intro__actions {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.tourism-intro__stats {
+  padding: 2.8rem;
+  border-radius: 28px;
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.92), rgba(124, 58, 237, 0.88));
+  color: #ffffff;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1.5rem;
+}
+
+.tourism-stat {
+  padding: 1.6rem;
+  border-radius: 22px;
+  background: rgba(255, 255, 255, 0.1);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.tourism-stat strong {
+  font-size: 2rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+}
+
+.tourism-stat span {
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.tourism-benefits {
+  padding-top: 5.5rem;
+  padding-bottom: 5.5rem;
+}
+
+.tourism-benefit-card {
+  padding: 2.6rem 2.4rem;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+}
+
+.tourism-benefit-card h3 {
+  font-size: 1.4rem;
+}
+
+.tourism-benefit-card p {
+  color: var(--color-muted);
+}
+
+.tourism-programs {
+  padding-top: 5.5rem;
+  padding-bottom: 5.5rem;
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0.03) 0%, rgba(15, 23, 42, 0) 100%);
+}
+
+.tourism-program-card {
+  padding: 2.6rem 2.4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.4rem;
+  height: 100%;
+  border: 1px solid rgba(37, 99, 235, 0.12);
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.tourism-program-card:hover {
+  transform: translateY(-8px);
+  box-shadow: var(--shadow-hover);
+}
+
+.program-badge {
+  align-self: flex-start;
+  padding: 0.4rem 1.1rem;
+  border-radius: 999px;
+  background: rgba(37, 99, 235, 0.12);
+  color: var(--color-primary);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  font-size: 0.72rem;
+}
+
+.program-features {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+}
+
+.program-features li {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  color: var(--color-muted);
+}
+
+.program-features i {
+  color: var(--color-secondary);
+}
+
+.program-cta {
+  margin-top: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.85rem 1.6rem;
+  border-radius: 999px;
+  background: linear-gradient(135deg, var(--color-primary), var(--color-secondary));
+  color: #ffffff;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.program-cta:hover {
+  color: #ffffff;
+  transform: translateY(-3px);
+  box-shadow: var(--shadow-hover);
+}
+
+.tourism-programs__disclaimer {
+  margin-top: 2.8rem;
+  padding: 1.3rem 1.6rem;
+  border-radius: 18px;
+  background: rgba(37, 99, 235, 0.08);
+  color: var(--color-primary);
+  font-weight: 500;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.8rem;
+}
+
+.tourism-process {
+  padding-top: 5.5rem;
+  padding-bottom: 5.5rem;
+}
+
+.tourism-process__grid {
+  margin-top: 3rem;
+  display: grid;
+  gap: 1.8rem;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.tourism-process__card {
+  padding: 2.4rem 2.2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.1rem;
+  border: 1px solid rgba(37, 99, 235, 0.1);
+}
+
+.tourism-process__card h3 {
+  font-size: 1.35rem;
+}
+
+.tourism-process__card p {
+  color: var(--color-muted);
+}
+
+.tourism-testimonials {
+  padding-top: 5.5rem;
+  padding-bottom: 5.5rem;
+  background: linear-gradient(135deg, rgba(124, 58, 237, 0.05) 0%, rgba(37, 99, 235, 0.05) 100%);
+}
+
+.tourism-testimonial {
+  padding: 2.4rem 2.2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.4rem;
+  height: 100%;
+  border: 1px solid rgba(124, 58, 237, 0.12);
+}
+
+.testimonial-text {
+  font-size: 1.05rem;
+  line-height: 1.7;
+  color: var(--color-dark);
+}
+
+.testimonial-author {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  color: var(--color-muted);
+}
+
+.testimonial-author strong {
+  font-size: 1rem;
+  color: var(--color-primary);
+}
+
+.tourism-quote {
+  padding-top: 5.5rem;
+  padding-bottom: 5.5rem;
+}
+
+.tourism-quote__panel {
+  padding: 3rem 3.2rem;
+  border-radius: 32px;
+  border: 1px solid rgba(37, 99, 235, 0.12);
+  box-shadow: 0 40px 70px rgba(15, 23, 42, 0.12);
+}
+
+.tourism-quote__content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.4rem;
+}
+
+.tourism-quote__content h2 {
+  font-size: 2.1rem;
+}
+
+.tourism-quote__form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+}
+
+.tourism-quote__form .form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.tourism-quote__form label {
+  font-weight: 600;
+  color: var(--color-dark);
+}
+
+.tourism-quote__form .form-control {
+  border-radius: 16px;
+  border: 1px solid rgba(15, 23, 42, 0.12);
+  padding: 0.85rem 1.1rem;
+  transition: border-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+.tourism-quote__form .form-control:focus {
+  border-color: rgba(37, 99, 235, 0.6);
+  box-shadow: 0 0 0 0.2rem rgba(37, 99, 235, 0.15);
+}
+
+.tourism-quote__form button {
+  align-self: flex-start;
+}
+
+.tourism-quote__message {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+  height: 0;
+  width: 0;
+  padding: 0;
+  margin: 0;
+  border: 0;
+}
+
+.tourism-quote .form-feedback p {
+  margin: 0;
+  font-weight: 600;
+}
+
+.tourism-quote .form-message-success {
+  color: var(--color-success, #059669);
+}
+
+.tourism-quote .form-message-error {
+  color: var(--color-danger, #dc2626);
+}
+
+@media (max-width: 991.98px) {
+  .tourism-intro__content,
+  .tourism-intro__stats,
+  .tourism-quote__panel {
+    border-radius: 24px;
+  }
+
+  .tourism-intro__stats {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .tourism-process__grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 767.98px) {
+  .tourism-intro,
+  .tourism-benefits,
+  .tourism-programs,
+  .tourism-process,
+  .tourism-testimonials,
+  .tourism-quote {
+    padding-top: 3.5rem;
+    padding-bottom: 3.5rem;
+  }
+
+  .tourism-intro__content {
+    padding: 2.4rem 2rem;
+  }
+
+  .tourism-intro__stats {
+    grid-template-columns: 1fr;
+  }
+
+  .tourism-process__grid {
+    grid-template-columns: 1fr;
+  }
+
+  .tourism-program-card,
+  .tourism-testimonial,
+  .tourism-benefit-card {
+    padding: 2.1rem 1.9rem;
+  }
+}
+
 .services-process .process-grid {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));

--- a/js/servicios.page.js
+++ b/js/servicios.page.js
@@ -1,8 +1,16 @@
-// JS extraído de servicios.html
+(() => {
+  function initPropertiesCarousel() {
+    if (!window.jQuery) {
+      return;
+    }
 
-// Inicializar el carrusel de propiedades
-    $(document).ready(function(){
-      $(".properties-carousel").owlCarousel({
+    window.jQuery(($) => {
+      const $carousel = $(".properties-carousel");
+      if (!$carousel.length || typeof $carousel.owlCarousel !== "function") {
+        return;
+      }
+
+      $carousel.owlCarousel({
         loop: true,
         margin: 30,
         nav: true,
@@ -12,14 +20,97 @@
         autoplayHoverPause: true,
         responsive: {
           0: {
-            items: 1
+            items: 1,
           },
           768: {
-            items: 1
+            items: 1,
           },
           992: {
-            items: 2
-          }
+            items: 2,
+          },
+        },
+      });
+    });
+  }
+
+  function initTourismQuoteForm() {
+    const form = document.getElementById("tourismQuoteForm");
+    if (!form) {
+      return;
+    }
+
+    const nameField = form.querySelector("input[name='name']");
+    const emailField = form.querySelector("input[name='email']");
+    const phoneField = form.querySelector("input[name='phone']");
+    const destinationField = form.querySelector("input[name='destination']");
+    const detailsField = form.querySelector("textarea[name='details']");
+    const messageField = form.querySelector("textarea[name='message']");
+
+    const updateMessageField = () => {
+      if (!messageField) {
+        return;
+      }
+
+      const details = [
+        "Nueva solicitud de turismo KayrosGo:",
+        `Nombre: ${nameField?.value || "---"}`,
+        `Email: ${emailField?.value || "---"}`,
+        `WhatsApp: ${phoneField?.value || "---"}`,
+        `Destino deseado: ${destinationField?.value || "---"}`,
+      ];
+
+      const extraDetails = detailsField?.value?.trim();
+      if (extraDetails) {
+        details.push("Detalles adicionales:", extraDetails);
+      }
+
+      messageField.value = details.join("\n");
+    };
+
+    const updateMessageWithDelay = () => {
+      window.requestAnimationFrame(updateMessageField);
+    };
+
+    form.addEventListener("input", updateMessageWithDelay);
+    form.addEventListener("change", updateMessageWithDelay);
+    form.addEventListener(
+      "submit",
+      () => {
+        updateMessageField();
+      },
+      true,
+    );
+    form.addEventListener("reset", () => {
+      window.requestAnimationFrame(() => {
+        if (destinationField) {
+          destinationField.value = "";
+        }
+        updateMessageField();
+      });
+    });
+
+    updateMessageField();
+
+    const programButtons = document.querySelectorAll("[data-program-destination]");
+    programButtons.forEach((button) => {
+      button.addEventListener("click", (event) => {
+        event.preventDefault();
+        const destination = button.getAttribute("data-program-destination") || "";
+        if (destinationField) {
+          destinationField.value = destination;
+          destinationField.dispatchEvent(new Event("input", { bubbles: true }));
+        }
+        updateMessageField();
+        form.scrollIntoView({ behavior: "smooth", block: "start" });
+        if (destinationField) {
+          destinationField.focus({ preventScroll: true });
         }
       });
     });
+  }
+
+  document.addEventListener("DOMContentLoaded", () => {
+    initPropertiesCarousel();
+    initTourismQuoteForm();
+  });
+})();

--- a/servicios.html
+++ b/servicios.html
@@ -58,6 +58,7 @@
           <div class="hero-actions">
             <a href="contacto.html" class="improved-btn improved-btn-primary">Agendar asesoría</a>
             <a href="#servicios" class="btn-secondary-outline">Ver catálogo de servicios</a>
+            <a href="#turismo" class="btn-secondary-outline btn-tourism-link">Turismo KayrosGo</a>
           </div>
           <div class="hero-metrics">
             <div class="metric">
@@ -95,6 +96,282 @@
             <li class="breadcrumb-item active" aria-current="page">Servicios</li>
           </ol>
         </nav>
+      </div>
+    </div>
+  </section>
+
+  <section class="section tourism-intro" id="turismo">
+    <div class="container">
+      <div class="row g-5 align-items-center">
+        <div class="col-lg-6">
+          <div class="tourism-intro__content surface-card">
+            <span class="tourism-tag"><i class="fa fa-plane"></i> Experiencias KayrosGo</span>
+            <h2>Viajes diseñados para invertir en recuerdos inolvidables</h2>
+            <p>Integramos el respaldo inmobiliario de CLE_BROKER con la trayectoria de KayrosGo para crear propuestas de
+              turismo hechas a tu medida. Desde escapadas de lujo hasta aventuras familiares, coordinamos cada detalle
+              con tarifas preferenciales y aliados confiables alrededor del mundo.</p>
+            <ul class="list-check">
+              <li><i class="fa fa-check"></i> Paquetes exclusivos con hoteles aliados 4* y 5*.</li>
+              <li><i class="fa fa-check"></i> Asesoría personalizada para armar itinerarios 5D/4N o más.</li>
+              <li><i class="fa fa-check"></i> Precios preferenciales en vuelos, autos, cruceros y experiencias.</li>
+            </ul>
+            <div class="tourism-intro__actions">
+              <a href="#tourism-programs" class="improved-btn improved-btn-primary">Programas destacados</a>
+              <a href="#tourismQuote" class="btn-secondary-outline">Solicitar cotización</a>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-6">
+          <div class="tourism-intro__stats surface-card">
+            <div class="tourism-stat">
+              <strong>5D/4N</strong>
+              <span>Planes ideales para desconectarte sin perder productividad.</span>
+            </div>
+            <div class="tourism-stat">
+              <strong>+25</strong>
+              <span>Hoteles aliados con upgrades y beneficios VIP.</span>
+            </div>
+            <div class="tourism-stat">
+              <strong>24/7</strong>
+              <span>Acompañamiento de travel planners especialistas.</span>
+            </div>
+            <div class="tourism-stat">
+              <strong>360°</strong>
+              <span>Cobertura en vuelos, autos de alquiler y cruceros temáticos.</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="section tourism-benefits">
+    <div class="container">
+      <div class="section-heading">
+        <div class="eyebrow"><i class="fa fa-suitcase"></i> ¿Por qué viajar con KayrosGo?</div>
+        <h2>Turismo estratégico que maximiza cada minuto</h2>
+        <p>Tu tiempo es tan valioso como tu inversión. Por eso, articulamos experiencias confiables, eficientes y
+          memorables para familias, parejas y equipos corporativos.</p>
+      </div>
+      <div class="row g-4">
+        <div class="col-md-4">
+          <div class="tourism-benefit-card surface-card">
+            <span class="icon-bubble"><i class="fa fa-star"></i></span>
+            <h3>Paquetes exclusivos</h3>
+            <p>Reservas con disponibilidad garantizada, upgrades de habitación y amenidades de bienvenida en los mejores
+              destinos de playa, ciudad y aventura.</p>
+          </div>
+        </div>
+        <div class="col-md-4">
+          <div class="tourism-benefit-card surface-card">
+            <span class="icon-bubble"><i class="fa fa-tags"></i></span>
+            <h3>Precios preferenciales</h3>
+            <p>Negociamos tarifas dinámicas con aerolíneas, navieras y rentadoras de autos para que aproveches promos y
+              beneficios especiales sin complicaciones.</p>
+          </div>
+        </div>
+        <div class="col-md-4">
+          <div class="tourism-benefit-card surface-card">
+            <span class="icon-bubble"><i class="fa fa-users"></i></span>
+            <h3>Asesoría personalizada</h3>
+            <p>Travel planners certificados que escuchan tus intereses, ajustan el plan a tu presupuesto y te acompañan
+              antes, durante y después del viaje.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="section tourism-programs" id="tourism-programs">
+    <div class="container">
+      <div class="section-heading">
+        <div class="eyebrow"><i class="fa fa-map"></i> Programas destacados</div>
+        <h2>Itinerarios favoritos de nuestros viajeros</h2>
+        <p>Seleccionamos rutas 5D/4N con la mejor relación costo-beneficio. Personaliza las noches, actividades y
+          servicios adicionales con nuestro equipo.</p>
+      </div>
+      <div class="row g-4">
+        <div class="col-lg-4">
+          <div class="tourism-program-card surface-card">
+            <span class="program-badge">Plan 5D/4N</span>
+            <h3>Cancún All Inclusive</h3>
+            <p>Vive el Caribe mexicano con traslados, club de playa privado y experiencias gastronómicas ilimitadas en
+              hotel 5* frente al mar.</p>
+            <ul class="program-features">
+              <li><i class="fa fa-bed"></i> Habitaciones deluxe con vista al mar</li>
+              <li><i class="fa fa-ship"></i> Excursión a Isla Mujeres con snorkel</li>
+              <li><i class="fa fa-car"></i> Upgrade opcional a auto premium</li>
+            </ul>
+            <a href="#tourismQuote" class="program-cta" data-program-destination="Cancún All Inclusive">Solicitar este
+              programa</a>
+          </div>
+        </div>
+        <div class="col-lg-4">
+          <div class="tourism-program-card surface-card">
+            <span class="program-badge">Circuito 10D</span>
+            <h3>Europa Express</h3>
+            <p>Recorre Madrid, París y Roma con guías en español, trenes de alta velocidad y experiencias culturales
+              curadas especialmente para ti.</p>
+            <ul class="program-features">
+              <li><i class="fa fa-university"></i> Visitas privadas en museos icónicos</li>
+              <li><i class="fa fa-cutlery"></i> Cenas gourmet con maridaje local</li>
+              <li><i class="fa fa-plane"></i> Vuelos intercontinentales con equipaje incluido</li>
+            </ul>
+            <a href="#tourismQuote" class="program-cta" data-program-destination="Europa Express">Solicitar este
+              programa</a>
+          </div>
+        </div>
+        <div class="col-lg-4">
+          <div class="tourism-program-card surface-card">
+            <span class="program-badge">Plan familiar</span>
+            <h3>Caribe Familiar</h3>
+            <p>Resorts todo incluido con clubes infantiles, suites conectadas y experiencias multi-generacionales que
+              unen a toda la familia.</p>
+            <ul class="program-features">
+              <li><i class="fa fa-child"></i> Actividades supervisadas para niños</li>
+              <li><i class="fa fa-spa"></i> Créditos de spa y experiencias wellness</li>
+              <li><i class="fa fa-camera"></i> Sesión fotográfica profesional en playa</li>
+            </ul>
+            <a href="#tourismQuote" class="program-cta" data-program-destination="Caribe Familiar">Solicitar este
+              programa</a>
+          </div>
+        </div>
+      </div>
+      <div class="tourism-programs__disclaimer">
+        <i class="fa fa-info-circle"></i> Ajusta fechas, aeropuertos de salida y experiencias opcionales (cruceros,
+        roadtrips o escapadas urbanas) con tu asesor KayrosGo.
+      </div>
+    </div>
+  </section>
+
+  <section class="section tourism-process">
+    <div class="container">
+      <div class="section-heading">
+        <div class="eyebrow"><i class="fa fa-compass"></i> Paso a paso KayrosGo</div>
+        <h2>Tu viaje ideal comienza con una conversación</h2>
+      </div>
+      <div class="tourism-process__grid">
+        <div class="tourism-process__card surface-card">
+          <span class="process-step">01</span>
+          <h3>Descubrimiento</h3>
+          <p>Conectamos por videollamada o WhatsApp para entender tu estilo de viaje, presupuesto y expectativas.</p>
+        </div>
+        <div class="tourism-process__card surface-card">
+          <span class="process-step">02</span>
+          <h3>Diseño del itinerario</h3>
+          <p>Presentamos propuestas comparables con tarifas, hoteles, experiencias y opciones de financiamiento.</p>
+        </div>
+        <div class="tourism-process__card surface-card">
+          <span class="process-step">03</span>
+          <h3>Confirmación</h3>
+          <p>Gestionamos reservas, seguros, traslados y upgrades, manteniéndote informado en cada paso.</p>
+        </div>
+        <div class="tourism-process__card surface-card">
+          <span class="process-step">04</span>
+          <h3>Disfrute y seguimiento</h3>
+          <p>Monitoreamos tu viaje 24/7 y respondemos cualquier imprevisto para que solo te concentres en disfrutar.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="section tourism-testimonials">
+    <div class="container">
+      <div class="section-heading">
+        <div class="eyebrow"><i class="fa fa-heart"></i> Historias de viajeros</div>
+        <h2>Testimonios que inspiran nuevas aventuras</h2>
+      </div>
+      <div class="row g-4">
+        <div class="col-md-4">
+          <div class="tourism-testimonial surface-card">
+            <p class="testimonial-text">“KayrosGo nos diseñó un itinerario en Cancún con actividades para todos. Los
+              niños adoraron el club infantil y nosotros aprovechamos el spa. Todo estuvo coordinado y sin sorpresas.”</p>
+            <div class="testimonial-author">
+              <strong>Familia Méndez</strong>
+              <span>Caribe Familiar</span>
+            </div>
+          </div>
+        </div>
+        <div class="col-md-4">
+          <div class="tourism-testimonial surface-card">
+            <p class="testimonial-text">“La asesoría fue impecable. Nos consiguieron asientos preferenciales y entradas
+              sin fila en museos de París. Definitivamente volveremos a planear nuestros viajes con KayrosGo.”</p>
+            <div class="testimonial-author">
+              <strong>Laura &amp; Miguel</strong>
+              <span>Europa Express</span>
+            </div>
+          </div>
+        </div>
+        <div class="col-md-4">
+          <div class="tourism-testimonial surface-card">
+            <p class="testimonial-text">“Coordinan todo: vuelos, traslados, reservas en restaurantes y hasta sorpresas de
+              aniversario. Se nota el respaldo de una agencia profesional.”</p>
+            <div class="testimonial-author">
+              <strong>Andrea R.</strong>
+              <span>Experiencia KayrosGo</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="section tourism-quote" id="tourismQuote">
+    <div class="container">
+      <div class="tourism-quote__panel surface-card">
+        <div class="row g-4">
+          <div class="col-lg-6">
+            <div class="tourism-quote__content">
+              <span class="tourism-tag"><i class="fa fa-envelope-open"></i> Solicita tu plan</span>
+              <h2>¿Listo para tu próxima aventura?</h2>
+              <p>Completa el formulario y un asesor KayrosGo te enviará una propuesta de viaje personalizada con tarifas
+                preferenciales, opciones de pago y recomendaciones de experiencias.</p>
+              <ul class="list-check">
+                <li><i class="fa fa-check"></i> Respuesta en menos de 24 horas hábiles.</li>
+                <li><i class="fa fa-check"></i> Ajustamos fechas, cantidad de viajeros y experiencias especiales.</li>
+                <li><i class="fa fa-check"></i> Cobertura integral: hoteles, autos, cruceros y seguros.</li>
+              </ul>
+            </div>
+          </div>
+          <div class="col-lg-6">
+            <form id="tourismQuoteForm" class="tourism-quote__form" data-endpoint="/api/contact"
+              data-success-message="¡Gracias! Nuestro equipo KayrosGo te contactará muy pronto."
+              data-error-message="No pudimos enviar tu solicitud. Inténtalo nuevamente." novalidate>
+              <input type="hidden" name="subject" value="Turismo KayrosGo">
+              <textarea name="message" class="tourism-quote__message" aria-hidden="true"></textarea>
+              <div class="form-group">
+                <label for="tourismName">Nombre completo</label>
+                <input type="text" id="tourismName" name="name" class="form-control" placeholder="Ingresa tu nombre"
+                  required>
+              </div>
+              <div class="form-group">
+                <label for="tourismEmail">Email</label>
+                <input type="email" id="tourismEmail" name="email" class="form-control"
+                  placeholder="correo@ejemplo.com" required>
+              </div>
+              <div class="form-group">
+                <label for="tourismPhone">WhatsApp</label>
+                <input type="tel" id="tourismPhone" name="phone" class="form-control"
+                  placeholder="Incluye indicativo país" required>
+              </div>
+              <div class="form-group">
+                <label for="tourismDestination">Destino o programa deseado</label>
+                <input type="text" id="tourismDestination" name="destination" class="form-control"
+                  placeholder="Ej: Cancún All Inclusive" required>
+              </div>
+              <div class="form-group">
+                <label for="tourismDetails">Cuéntanos más sobre tu viaje</label>
+                <textarea id="tourismDetails" name="details" class="form-control" rows="3"
+                  placeholder="Fechas tentativas, número de viajeros, intereses especiales..."></textarea>
+              </div>
+              <div class="form-feedback">
+                <p class="form-message-success" hidden></p>
+                <p class="form-message-error" hidden></p>
+              </div>
+              <button type="submit" class="improved-btn improved-btn-primary">Solicitar cotización personalizada</button>
+            </form>
+          </div>
+        </div>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Summary
- add a KayrosGo tourism experience block to the services page with highlighted programs, beneficios y testimonios
- style the new tourism sections and hero link to match the existing visual language
- enhance the services page script to support the tourism quote form and prefill requests from featured programs

## Testing
- python3 -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68e9cad0e5bc832aa825a800ebc15c1a